### PR TITLE
[CU-863h754cb] Update infra and gitea version to v0.18.1

### DIFF
--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.17.2
-appVersion: v0.17.1
+version: 0.18.1
+appVersion: v0.18.1


### PR DESCRIPTION
- Updating Infra and Gitea app version to v0.18.1
- https://github.com/copia-automation/gitea-fork/releases/tag/v0.18.1
- https://app.clickup.com/45000662/v/dc/1ax9yp-27507/1ax9yp-12060