### PR TITLE
[86a218mxt] Bump infra and gitea version to 0,.25.0 for Self Hosted Release

### DIFF
--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.24.0
-appVersion: v0.24.0
+version: 0.25.0
+appVersion: v0.25.0


### PR DESCRIPTION
This will be merged only after all items checklist in https://app.clickup.com/t/86a218mx6(https://app.clickup.com/45000662/v/dc/1ax9yp-27507/1ax9yp-12060) are complete