### PR TITLE
[CU-86a28d87w] Bump infra and gitea version to 0.26.0 for Self Hosted Release

### DIFF
--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.25.0
-appVersion: v0.25.0
+version: 0.26.0
+appVersion: v0.26.0


### PR DESCRIPTION
- Tracking [checklist](https://app.clickup.com/t/86a28d87w)