### PR TITLE
Helm chart improvements

### DIFF
--- a/charts/copia/templates/configmap.yaml
+++ b/charts/copia/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.copia.config.server }}
+{{- if .Values.deployment.configmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 data:
-  {{- range $key, $value := .Values.copia.config.server }}
+  {{- range $key, $value := .Values.deployment.configmap }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}

--- a/charts/copia/templates/configmap.yaml
+++ b/charts/copia/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.deployment.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}-configmap
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.deployment.env }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/copia/templates/deployment.yaml
+++ b/charts/copia/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
               mountPath: {{ .Values.deployment.configuration.GITEA_TEMP }}
             - name     : data
               mountPath: {{ .Values.deployment.configuration.GITEA_WORK_DIR }}
-            {{- if (hasKey .Values.copia "deployment") }}
+            {{- if (hasKey .Values.deployment "configuration") }}
             - name     : config
               mountPath: {{ .Values.deployment.configuration.GITEA_APP_INI }}
               subPath  : app.ini

--- a/charts/copia/templates/deployment.yaml
+++ b/charts/copia/templates/deployment.yaml
@@ -23,7 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- with .Values.copia.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -53,51 +54,22 @@ spec:
           command:
             - gitea
           env:
-            # SSH Port values have to be set here as well for openssh configuration
-            {{- if (hasKey .Values.copia "config") }}
-            - name: SSH_LISTEN_PORT
-              value: {{ .Values.copia.config.server.SSH_LISTEN_PORT | default "22" | quote }}
-            - name: SSH_PORT
-              value: {{ .Values.copia.config.server.SSH_PORT | default "22" | quote }}
-            {{- else }}
-            - name: SSH_LISTEN_PORT
-              value: "22"
-            - name: SSH_PORT
-              value: "22"
-            {{- end }}
-            - name: GITEA_APP_INI
-              value: /data/gitea/conf/app.ini
-            - name: GITEA_CUSTOM
-              value: /data/gitea
-            - name: GITEA_WORK_DIR
-              value: /data
-            - name: GITEA_TEMP
-              value: /tmp/gitea
-            - name: TMPDIR
-              value: /tmp/gitea
             {{- if .Values.signing.enabled }}
             - name: GNUPGHOME
               value: {{ .Values.signing.gpgHome }}
             {{- end }}
-            {{- if .Values.deployment.env }}
-            {{- toYaml .Values.deployment.env | nindent 12 }}
-            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "app.fullname" . }}-configmap
           ports:
-            {{- if (hasKey .Values.copia "config") }}
             - name: ssh
-              containerPort: {{ .Values.copia.config.server.SSH_LISTEN_PORT | default "22" }}
+              containerPort: {{ .Values.copia.config.server.SSH_LISTEN_PORT }}
             - name: http
-              containerPort: {{ .Values.copia.config.server.HTTP_PORT | default "4001" }}
+              containerPort: {{ .Values.copia.config.server.HTTP_PORT }}
               {{- if .Values.copia.config.server.ENABLE_PPROF }}
             - name: profiler
-              containerPort: 6060
+              containerPort: {{ .Values.copia.config.server.PPROF_PORT }}
               {{- end }}
-            {{- else }}
-            - name: ssh
-              containerPort: 22
-            - name: http
-              containerPort: 4001
-            {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -150,9 +122,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name     : temp
-              mountPath: /tmp/gitea
+              mountPath: {{ .Values.deployment.env.GITEA_TEMP }}
             - name     : data
-              mountPath: /data
+              mountPath: {{ .Values.deployment.env.GITEA_WORK_DIR }}
             {{- if (hasKey .Values.copia "config") }}
             - name     : config
               mountPath: /data/gitea/conf/app.ini

--- a/charts/copia/templates/deployment.yaml
+++ b/charts/copia/templates/deployment.yaml
@@ -66,12 +66,12 @@ spec:
                 name: {{ include "app.fullname" . }}-configmap
           ports:
             - name: ssh
-              containerPort: {{ .Values.deployment.configuration.POD_SSH_LISTEN_PORT }}
+              containerPort: {{ .Values.deployment.configmap.SSH_LISTEN_PORT }}
             - name: http
-              containerPort: {{ .Values.copia.config.server.HTTP_PORT }}
-              {{- if .Values.deployment.configuration.ENABLE_PPROF }}
+              containerPort: {{ .Values.copia_server_http_port }}
+              {{- if .Values.deployment.configmap.ENABLE_PPROF }}
             - name: profiler
-              containerPort: {{ .Values.deployment.configuration.PPROF_PORT }}
+              containerPort: {{ .Values.deployment.configmap.PPROF_PORT }}
               {{- end }}
           lifecycle:
             preStop:
@@ -125,12 +125,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name     : temp
-              mountPath: {{ .Values.deployment.configuration.GITEA_TEMP }}
+              mountPath: {{ .Values.deployment.configmap.GITEA_TEMP }}
             - name     : data
-              mountPath: {{ .Values.deployment.configuration.GITEA_WORK_DIR }}
-            {{- if (hasKey .Values.deployment "configuration") }}
+              mountPath: {{ .Values.deployment.configmap.GITEA_WORK_DIR }}
+            {{- if (hasKey .Values.copia "config") }}
             - name     : config
-              mountPath: {{ .Values.deployment.configuration.GITEA_APP_INI }}
+              mountPath: {{ .Values.deployment.configmap.GITEA_APP_INI }}
               subPath  : app.ini
             {{- end }}
             {{- if .Values.extraVolumeMounts }}

--- a/charts/copia/templates/deployment.yaml
+++ b/charts/copia/templates/deployment.yaml
@@ -66,12 +66,12 @@ spec:
                 name: {{ include "app.fullname" . }}-configmap
           ports:
             - name: ssh
-              containerPort: {{ .Values.copia.config.server.SSH_LISTEN_PORT }}
+              containerPort: {{ .Values.deployment.configuration.POD_SSH_LISTEN_PORT }}
             - name: http
               containerPort: {{ .Values.copia.config.server.HTTP_PORT }}
-              {{- if .Values.copia.config.server.ENABLE_PPROF }}
+              {{- if .Values.deployment.configuration.ENABLE_PPROF }}
             - name: profiler
-              containerPort: {{ .Values.copia.config.server.PPROF_PORT }}
+              containerPort: {{ .Values.deployment.configuration.PPROF_PORT }}
               {{- end }}
           lifecycle:
             preStop:
@@ -125,12 +125,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name     : temp
-              mountPath: {{ .Values.copia.config.server.GITEA_TEMP }}
+              mountPath: {{ .Values.deployment.configuration.GITEA_TEMP }}
             - name     : data
-              mountPath: {{ .Values.copia.config.server.GITEA_WORK_DIR }}
-            {{- if (hasKey .Values.copia "config") }}
+              mountPath: {{ .Values.deployment.configuration.GITEA_WORK_DIR }}
+            {{- if (hasKey .Values.copia "deployment") }}
             - name     : config
-              mountPath: /data/gitea/conf/app.ini
+              mountPath: {{ .Values.deployment.configuration.GITEA_APP_INI }}
               subPath  : app.ini
             {{- end }}
             {{- if .Values.extraVolumeMounts }}

--- a/charts/copia/templates/secret.yaml
+++ b/charts/copia/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if hasKey .Values.copia "ini" }}
+{{- if hasKey .Values.copia "config" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +9,7 @@ type: Opaque
 stringData:
   app.ini: |
     {{- /* autogenerate app.ini */ -}}
-    {{- range $key, $value := .Values.copia.ini  }}
+    {{- range $key, $value := .Values.copia.config  }}
     {{- if kindIs "map" $value }}
     {{- if gt (len $value) 0 }}
 

--- a/charts/copia/templates/secret.yaml
+++ b/charts/copia/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if hasKey .Values.copia "config" }}
+{{- if hasKey .Values.copia "ini" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +9,7 @@ type: Opaque
 stringData:
   app.ini: |
     {{- /* autogenerate app.ini */ -}}
-    {{- range $key, $value := .Values.copia.config  }}
+    {{- range $key, $value := .Values.copia.ini  }}
     {{- if kindIs "map" $value }}
     {{- if gt (len $value) 0 }}
 

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -325,9 +325,10 @@
       "description": "App configuration.",
       "required": [],
       "properties": {
-        "configuration": {
+        "configmap": {
           "type": "object",
-          "additionalProperties": false,
+          "description": "Environment variables via configmap.",
+          "additionalProperties": true,
           "properties": {
             "POD_SSH_LISTEN_PORT": {
               "type": "number"
@@ -351,10 +352,6 @@
               "type": "number"
             }
           }
-        },
-        "configmap": {
-          "type": "array",
-          "description": "Environment variables via configmap."
         },
         "env": {
           "type": "array",

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -325,6 +325,37 @@
       "description": "App configuration.",
       "required": [],
       "properties": {
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "POD_SSH_LISTEN_PORT": {
+              "type": "number"
+            },
+            "GITEA_APP_INI": {
+              "type": "string"
+            },
+            "GITEA_CUSTOM": {
+              "type": "string"
+            },
+            "GITEA_WORK_DIR": {
+              "type": "string"
+            },
+            "GITEA_TEMP": {
+              "type": "string"
+            },
+            "ENABLE_PPROF": {
+              "type": "boolean"
+            },
+            "PPROF_PORT": {
+              "type": "number"
+            }
+          }
+        },
+        "configmap": {
+          "type": "array",
+          "description": "Environment variables via configmap."
+        },
         "env": {
           "type": "array",
           "description": "Environment variables."

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -171,6 +171,34 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "server": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "SSH_LISTEN_PORT": {
+                  "type": "number"
+                },
+                "HTTP_PORT": {
+                  "type": "number"
+                },
+                "ENABLE_PPROF": {
+                  "type": "boolean"
+                },
+                "PPROF_PORT": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "ini": {
+          "type": "object",
+          "additionalProperties": true
+        },
         "livenessProbe": {
           "type": "object",
           "additionalProperties": false,
@@ -268,7 +296,32 @@
       "properties": {
         "env": {
           "type": "object",
-          "description": "Environment variables."
+          "description": "Environment variables.",
+          "additionalProperties": true,
+          "required": ["SSH_LISTEN_PORT", "SSH_PORT", "GITEA_APP_INI", "GITEA_CUSTOM", "GITEA_WORK_DIR", "GITEA_TEMP", "TMPDIR"],
+          "properties": {
+            "SSH_LISTEN_PORT": {
+              "type": "number"
+            },
+            "SSH_PORT": {
+              "type": "number"
+            },
+            "GITEA_APP_INI": {
+              "type": "string"
+            },
+            "GITEA_CUSTOM": {
+              "type": "string"
+            },
+            "GITEA_WORK_DIR": {
+              "type": "string"
+            },
+            "GITEA_TEMP": {
+              "type": "string"
+            },
+            "TMPDIR": {
+              "type": "string"
+            }
+          }
         },
         "terminationGracePeriodSeconds": {
           "type": "number",

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -47,41 +47,33 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 deployment:
+  configuration:
+    POD_SSH_LISTEN_PORT: 22
+    GITEA_APP_INI: /data/gitea/conf/app.ini
+    GITEA_CUSTOM: /data/gitea
+    GITEA_WORK_DIR: /data
+    GITEA_TEMP: /tmp/gitea
+    ENABLE_PPROF: false
+    PPROF_PORT: 6060
+  configmap: []
+    # ACD_CONVERSION_URL: https://rockwell-tools.copia.io/convertOctetStream
+    # ROCKWELL_V35_CONVERSION_URL: https://rockwell-v35.copia.io/convertOctetStream
+    # ROCKWELL_V35_IMPORT_CONVERSION_URL: https://rockwell-v35.copia.io/convertL5xToAcd
+    # ZAP14_CONVERSION_URL: http://zap2zipv14.copia.io:9694
+    # ZAP15_0_CONVERSION_URL: http://zap2zipv15-0.copia.io:9695
+    # ZAP15_CONVERSION_URL: http://zap2zipv15.copia.io:9695
+    # ZAP16_CONVERSION_URL: http://zap2zip.copia.io:9696
+    # ZAP17_CONVERSION_URL: http://zap2zipv17.copia.io:9697
+    # ACD_IMPORT_CONVERSION_URL: https://rockwell-tools.copia.io/convertL5xToAcd
+    # ZAP14_IMPORT_CONVERSION_URL: http://zap2zipv14.copia.io:9694/import
+    # ZAP15_0_IMPORT_CONVERSION_URL: http://zap2zipv15-0.copia.io:9695/import
+    # ZAP15_IMPORT_CONVERSION_URL: http://zap2zipv15.copia.io:9695/import
+    # ZAP16_IMPORT_CONVERSION_URL: http://zap2zip.copia.io:9696/import
+    # ZAP17_IMPORT_CONVERSION_URL: http://zap2zipv17.copia.io:9697/import
+    # CODESYS_CONVERSION_URL: http://codesys.copia.io:8888/export
+    # CODESYS_IMPORT_CONVERSION_URL: http://codesys.copia.io:8888/import
+    # CONTROL_EXPERT_CONVERSION_URL: http://control-expert.copia.io:9696/export
   env: []
-    # - name: ACD_CONVERSION_URL
-    #   value: https://rockwell-tools.copia.io/convertOctetStream
-    # - name: ROCKWELL_V35_CONVERSION_URL
-    #   value: https://rockwell-v35.copia.io/convertOctetStream
-    # - name: ROCKWELL_V35_IMPORT_CONVERSION_URL
-    #   value: https://rockwell-v35.copia.io/convertL5xToAcd
-    # - name: ZAP14_CONVERSION_URL
-    #   value: http://zap2zipv14.copia.io:9694
-    # - name: ZAP15_0_CONVERSION_URL
-    #   value: http://zap2zipv15-0.copia.io:9695
-    # - name: ZAP15_CONVERSION_URL
-    #   value: http://zap2zipv15.copia.io:9695
-    # - name: ZAP16_CONVERSION_URL
-    #   value: http://zap2zip.copia.io:9696
-    # - name: ZAP17_CONVERSION_URL
-    #   value: http://zap2zipv17.copia.io:9697
-    # - name: ACD_IMPORT_CONVERSION_URL
-    #   value: https://rockwell-tools.copia.io/convertL5xToAcd
-    # - name: ZAP14_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv14.copia.io:9694/import
-    # - name: ZAP15_0_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv15-0.copia.io:9695/import
-    # - name: ZAP15_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv15.copia.io:9695/import
-    # - name: ZAP16_IMPORT_CONVERSION_URL
-    #   value: http://zap2zip.copia.io:9696/import
-    # - name: ZAP17_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv17.copia.io:9697/import
-    # - name: CODESYS_CONVERSION_URL
-    #   value: http://codesys.copia.io:8888/export
-    # - name: CODESYS_IMPORT_CONVERSION_URL
-    #   value: http://codesys.copia.io:8888/import
-    # - name: CONTROL_EXPERT_CONVERSION_URL
-    #   value: http://control-expert.copia.io:9696/export
   terminationGracePeriodSeconds: 60
   labels: {}
   rollingUpdate:
@@ -129,18 +121,9 @@ copia:
     failureThreshold: 2
   config:
     server:
-      HTTP_PORT: 4001
-      SSH_LISTEN_PORT: 22
       SSH_PORT: 22
-      GITEA_APP_INI: /data/gitea/conf/app.ini
-      GITEA_CUSTOM: /data/gitea
-      GITEA_WORK_DIR: /data
-      GITEA_TEMP: /tmp/gitea
-      TMPDIR: /tmp/gitea
       HTTP_PORT: 4001
-      ENABLE_PPROF: false
-      PPROF_PORT: 6060
-  #   LFS_JWT_SECRET: <REQUIRED>
+  #     LFS_JWT_SECRET: <REQUIRED>
   #   APP_NAME: "Copia"
   #   RUN_MODE: production
   #   oauth2:

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -47,41 +47,31 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 deployment:
-  env: {}
-    # - name: ACD_CONVERSION_URL
-    #   value: https://rockwell-tools.copia.io/convertOctetStream
-    # - name: ROCKWELL_V35_CONVERSION_URL
-    #   value: https://rockwell-v35.copia.io/convertOctetStream
-    # - name: ROCKWELL_V35_IMPORT_CONVERSION_URL
-    #   value: https://rockwell-v35.copia.io/convertL5xToAcd
-    # - name: ZAP14_CONVERSION_URL
-    #   value: http://zap2zipv14.copia.io:9694
-    # - name: ZAP15_0_CONVERSION_URL
-    #   value: http://zap2zipv15-0.copia.io:9695
-    # - name: ZAP15_CONVERSION_URL
-    #   value: http://zap2zipv15.copia.io:9695
-    # - name: ZAP16_CONVERSION_URL
-    #   value: http://zap2zip.copia.io:9696
-    # - name: ZAP17_CONVERSION_URL
-    #   value: http://zap2zipv17.copia.io:9697
-    # - name: ACD_IMPORT_CONVERSION_URL
-    #   value: https://rockwell-tools.copia.io/convertL5xToAcd
-    # - name: ZAP14_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv14.copia.io:9694/import
-    # - name: ZAP15_0_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv15-0.copia.io:9695/import
-    # - name: ZAP15_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv15.copia.io:9695/import
-    # - name: ZAP16_IMPORT_CONVERSION_URL
-    #   value: http://zap2zip.copia.io:9696/import
-    # - name: ZAP17_IMPORT_CONVERSION_URL
-    #   value: http://zap2zipv17.copia.io:9697/import
-    # - name: CODESYS_CONVERSION_URL
-    #   value: http://codesys.copia.io:8888/export
-    # - name: CODESYS_IMPORT_CONVERSION_URL
-    #   value: http://codesys.copia.io:8888/import
-    # - name: CONTROL_EXPERT_CONVERSION_URL
-    #   value: http://control-expert.copia.io:9696/export
+  env:
+    SSH_LISTEN_PORT: 22
+    SSH_PORT: 22
+    GITEA_APP_INI: /data/gitea/conf/app.ini
+    GITEA_CUSTOM: /data/gitea
+    GITEA_WORK_DIR: /data
+    GITEA_TEMP: /tmp/gitea
+    TMPDIR: /tmp/gitea
+    #ACD_CONVERSION_URL: https://rockwell-tools.copia.io/convertOctetStream
+    #ROCKWELL_V35_CONVERSION_URL: https://rockwell-v35.copia.io/convertOctetStream
+    #ROCKWELL_V35_IMPORT_CONVERSION_URL: https://rockwell-v35.copia.io/convertL5xToAcd
+    #ZAP14_CONVERSION_URL: http://zap2zipv14.copia.io:9694
+    #ZAP15_0_CONVERSION_URL: http://zap2zipv15-0.copia.io:9695
+    #ZAP15_CONVERSION_URL: http://zap2zipv15.copia.io:9695
+    #ZAP16_CONVERSION_URL: http://zap2zip.copia.io:9696
+    #ZAP17_CONVERSION_URL: http://zap2zipv17.copia.io:9697
+    #ACD_IMPORT_CONVERSION_URL: https://rockwell-tools.copia.io/convertL5xToAcd
+    #ZAP14_IMPORT_CONVERSION_URL: http://zap2zipv14.copia.io:9694/import
+    #ZAP15_0_IMPORT_CONVERSION_URL: http://zap2zipv15-0.copia.io:9695/import
+    #ZAP15_IMPORT_CONVERSION_URL: http://zap2zipv15.copia.io:9695/import
+    #ZAP16_IMPORT_CONVERSION_URL: http://zap2zip.copia.io:9696/import
+    #ZAP17_IMPORT_CONVERSION_URL: http://zap2zipv17.copia.io:9697/import
+    #CODESYS_CONVERSION_URL: http://codesys.copia.io:8888/export
+    #CODESYS_IMPORT_CONVERSION_URL: http://codesys.copia.io:8888/import
+    #CONTROL_EXPERT_CONVERSION_URL: http://control-expert.copia.io:9696/export
   terminationGracePeriodSeconds: 60
   labels: {}
   rollingUpdate:
@@ -127,14 +117,19 @@ copia:
     periodSeconds   : 10
     timeoutSeconds  : 2
     failureThreshold: 2
-  # config:
+  config:
+    server:
+      SSH_LISTEN_PORT: 22
+      HTTP_PORT: 4001
+      ENABLE_PPROF: false
+      PPROF_PORT: 6060
+  #   LFS_JWT_SECRET: <REQUIRED>
+  ini: {}
   #   APP_NAME: "Copia"
   #   RUN_MODE: production
   #   oauth2:
   #     JWT_SECRET: <REQUIRED>
   #   security:
   #     INTERNAL_TOKEN: <REQUIRED>
-  #   server:
-  #     LFS_JWT_SECRET: <REQUIRED>
   #   copia:
   #     LICENSE_KEY: <REQUIRED>

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 clusterDomain: cluster.local
+#Use this value "*copia_port" to reference the value of the copia_server_http_port when setting HTTP_PORT on the copia config.
+copia_server_http_port: &copia_port 4001
 image:
   repository: copiaio/copia
   pullPolicy: Always
@@ -8,7 +10,7 @@ service:
   http:
     type: NodePort
     port: 3000
-    targetPort: 4001
+    targetPort: *copia_port
     #clusterIP: None
     #loadBalancerIP:
     #nodePort:
@@ -47,15 +49,15 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 deployment:
-  configuration:
-    POD_SSH_LISTEN_PORT: 22
+  configmap:
+    SSH_LISTEN_PORT: 22
     GITEA_APP_INI: /data/gitea/conf/app.ini
     GITEA_CUSTOM: /data/gitea
     GITEA_WORK_DIR: /data
     GITEA_TEMP: /tmp/gitea
+    TMPDIR: /tmp/gitea
     ENABLE_PPROF: false
     PPROF_PORT: 6060
-  configmap: []
     # ACD_CONVERSION_URL: https://rockwell-tools.copia.io/convertOctetStream
     # ROCKWELL_V35_CONVERSION_URL: https://rockwell-v35.copia.io/convertOctetStream
     # ROCKWELL_V35_IMPORT_CONVERSION_URL: https://rockwell-v35.copia.io/convertL5xToAcd
@@ -107,7 +109,7 @@ copia:
   customStartupProbe:
     httpGet:
       path: /
-      port: 4001
+      port: *copia_port
     initialDelaySeconds: 10
     periodSeconds      : 5
     timeoutSeconds     : 2
@@ -115,14 +117,14 @@ copia:
   customLivenessProbe:
     httpGet:
       path: /
-      port: 4001
+      port: *copia_port
     periodSeconds   : 10
     timeoutSeconds  : 2
     failureThreshold: 2
-  config:
-    server:
-      SSH_PORT: 22
-      HTTP_PORT: 4001
+  # config:
+  #   server:
+  #     SSH_PORT: 22
+  #     HTTP_PORT: *copia_port
   #     LFS_JWT_SECRET: <REQUIRED>
   #   APP_NAME: "Copia"
   #   RUN_MODE: production

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -140,6 +140,7 @@ copia:
       HTTP_PORT: 4001
       ENABLE_PPROF: false
       PPROF_PORT: 6060
+  #   LFS_JWT_SECRET: <REQUIRED>
   #   APP_NAME: "Copia"
   #   RUN_MODE: production
   #   oauth2:


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86a44v7d9

On this PR we're:
 - Moving environment varables into a configmap. Backwards compatible to previous values.yaml.
 - Renaming config.yaml to secrets.yaml
 - Adding validation for Env Vars

Tested on Sandbox:
```
  History:
    App Version:                  v0.29.0
    Chart Name:                   copia
    Chart Version:                0.29.0-beta
    Config Digest:                sha256:bc7f553ae4dd2435fc6b841dc632b2088ef6fb97ea5e63205bd23fa308c56bb6
    Digest:                       sha256:106fe929875372a849aefb95bbfa2d722a019ca0306b4e0199cbc9e296cd6a18
    First Deployed:               2023-07-17T14:52:33Z
    Last Deployed:                2024-07-23T08:25:15Z
    Name:                         copia
    Namespace:                    copia
    Status:                       deployed
    Version:                      220
    App Version:                  v0.12.0
    Chart Name:                   copia
    Chart Version:                0.12.0
    Config Digest:                sha256:bc7f553ae4dd2435fc6b841dc632b2088ef6fb97ea5e63205bd23fa308c56bb6
    Digest:                       sha256:422652158052ac2536696bdeb21f540829290d0f2d2453b6628e072dc4cce671
    First Deployed:               2023-07-17T14:52:33Z
    Last Deployed:                2024-07-19T14:05:18Z
    Name:                         copia
    Namespace:                    copia
    Status:                       superseded
    Version:                      219
  Last Attempted Config Digest:   sha256:bc7f553ae4dd2435fc6b841dc632b2088ef6fb97ea5e63205bd23fa308c56bb6
  Last Attempted Generation:      304
  Last Attempted Release Action:  upgrade
  Last Attempted Revision:        0.29.0-beta
  Observed Generation:            304
  Storage Namespace:              copia
Events:
  Type    Reason               Age                From             Message
  ----    ------               ----               ----             -------
  Normal  HelmChartConfigured  24s (x4 over 27d)  helm-controller  Configured HelmChart/flux-system/copia-copia with SourceRef 'HelmRepository/flux-system/copia-chart'
  Normal  UpgradeSucceeded     7s                 helm-controller  Helm upgrade succeeded for release copia/copia.v220 with chart copia@0.29.0-beta
```
```
> kubectl -n copia get pods
NAME                                  READY   STATUS    RESTARTS   AGE
conversion-manager-6447cb949b-p8lkt   1/1     Running   0          3d8h
copia-76f5d69867-cm6qt                1/1     Running   0          3m35s
fabric-8cb6f66bb-2s5wt                1/1     Running   0          11h
fabric-8cb6f66bb-cgkcb                1/1     Running   0          11h
fabric-8cb6f66bb-wfj7q                1/1     Running   0          11h
```