### PR TITLE
Fixes values schema file

### DIFF
--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -6,7 +6,6 @@
     "k8s": {
       "resources": {
         "type": "object",
-        "required": ["cpu", "memory"],
         "properties": {
           "cpu": {
             "type": "number"
@@ -169,8 +168,68 @@
     },
     "copia": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "security": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "INSTALL_LOCK": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "database": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "DB_TYPE": {
+                  "type": "string"
+                },
+                "HOST": {
+                  "type": "string"
+                },
+                "NAME": {
+                  "type": "string"
+                }
+              }
+            },
+            "job_run_results": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "MINIO_BUCKET": {
+                  "type": "string"
+                }
+              }
+            },
+            "fileconvert_cache": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "MINIO_BUCKET": {
+                  "type": "string"
+                }
+              }
+            },
+            "conversion_manager": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "ENABLED": {
+                  "type": "boolean"
+                },
+                "CONVERSION_TYPES": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
         "livenessProbe": {
           "type": "object",
           "additionalProperties": false,
@@ -267,7 +326,7 @@
       "required": [],
       "properties": {
         "env": {
-          "type": "object",
+          "type": "array",
           "description": "Environment variables."
         },
         "terminationGracePeriodSeconds": {
@@ -304,7 +363,7 @@
           "type": "boolean"
         },
         "existingClaim": {
-          "type": "object",
+          "type": "string",
           "description": "Existing PVC name"
         },
         "size": {
@@ -326,17 +385,19 @@
         "storageClassName": {
           "type": "string",
           "description": "Storage class name."
+        },
+        "storageClass": {
+          "type": "string",
+          "description": "Storage class name."
         }
       }
     },
     "extraVolumes": {
-      "type": "object",
-      "additionalProperties": true,
+      "type": "array",
       "description": "Extra volumes configuration."
     },
     "extraVolumeMounts": {
-      "type": "object",
-      "additionalProperties": true,
+      "type": "array",
       "description": "Extra volumes configuration."
     },
     "initPreScript": {

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -47,7 +47,7 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 deployment:
-  env: {}
+  env: []
     # - name: ACD_CONVERSION_URL
     #   value: https://rockwell-tools.copia.io/convertOctetStream
     # - name: ROCKWELL_V35_CONVERSION_URL
@@ -89,7 +89,7 @@ deployment:
     maxUnavailable: 0
 persistence:
   enabled: true
-  existingClaim: {}
+  existingClaim: ""
   size: 10Gi
   accessModes:
     - ReadWriteOnce
@@ -97,8 +97,8 @@ persistence:
   annotations: {}
   #storageClassName:
 # additional volumes to add to the deployment.
-extraVolumes: {}
-extraVolumeMounts: {}
+extraVolumes: []
+extraVolumeMounts: []
 # bash shell script copied verbatim to the start of the init-container.
 initPreScript: ""
 # Configure commit/action signing prerequisites
@@ -127,7 +127,9 @@ copia:
     periodSeconds   : 10
     timeoutSeconds  : 2
     failureThreshold: 2
-  # config:
+  config:
+    server:
+      HTTP_PORT: 4001
   #   APP_NAME: "Copia"
   #   RUN_MODE: production
   #   oauth2:


### PR DESCRIPTION
This PR fixes the `values.schema.json` file to work with our typically provided values.

```
MBP-M3-Pro ~/Projects/Copia/helm-charts(fix/values.schema.json|✔) % helm lint charts/copia -f ../production.yaml
==> Linting charts/copia
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
MBP-M3-Pro ~/Projects/Copia/helm-charts(fix/values.schema.json|✔) % helm lint charts/copia -f ../sandbox.yaml
==> Linting charts/copia
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```