### PR TITLE
Validations (ghcr secrets)

### DIFF
--- a/charts/copia/Changelog.md
+++ b/charts/copia/Changelog.md
@@ -1,11 +1,30 @@
 # Change Log
 
-## Next Release 
+## 0.39.2 
+
+**Release date:** 2024-11-26
 
 ![AppVersion: v0.35.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.35.0&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
+* bump chart version 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
+## 0.39.1 
+
+**Release date:** 2024-11-26
+
+![AppVersion: v0.35.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.35.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* bump chart version ensures hook was deleted prior run 
 * ensures hook was deleted prior run 
 * force pull policy 
 

--- a/charts/copia/Changelog.md
+++ b/charts/copia/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Next Release 
+
+![AppVersion: v0.35.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.35.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* ensures hook was deleted prior run 
+* force pull policy 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.39.0 
 
 **Release date:** 2024-11-26

--- a/charts/copia/Changelog.md
+++ b/charts/copia/Changelog.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 0.39.0 
+
+**Release date:** 2024-11-26
+
+![AppVersion: v0.35.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.35.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Adds pre-install hook 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.38.1 
 
 **Release date:** 2024-11-18
@@ -8,8 +24,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* update Chart.yaml and Changelog.md 
-* update conversion manager container name
+* update conversion manager container name (#84) 
 
 ### Default value changes
 
@@ -25,7 +40,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* update Chart.yaml and Changelog.md 
+* Update Chart.yaml for self-hosted release v0.35.0 (#83) 
 
 ### Default value changes
 

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.38.1
+version: 0.39.0
 appVersion: v0.35.0
 cmVersion: v0.1.0

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.39.1
+version: 0.39.2
 appVersion: v0.35.0
 cmVersion: v0.1.0

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.39.0
+version: 0.39.1
 appVersion: v0.35.0
 cmVersion: v0.1.0

--- a/charts/copia/templates/pre-install-hooks.yaml
+++ b/charts/copia/templates/pre-install-hooks.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/charts/copia/templates/pre-install-hooks.yaml
+++ b/charts/copia/templates/pre-install-hooks.yaml
@@ -29,4 +29,5 @@ spec:
       containers:
       - name: pre-install-job-ghcr
         image: "{{ include "app.image" . }}"
+        imagePullPolicy: Always
         command: ["/bin/sleep","{{ default '5' }}"]

--- a/charts/copia/templates/pre-install-hooks.yaml
+++ b/charts/copia/templates/pre-install-hooks.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-ghcr"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-ghcr"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: pre-install-job-ghcr
+        image: "{{ include "app.image" . }}"
+        command: ["/bin/sleep","{{ default '5' }}"]


### PR DESCRIPTION
This pre-install hook ensures the ghcr secret is installed and functional.

Errored state:
```
Release "copia" does not exist. Installing it now.
Pulled: ghcr.io/copia-automation/helm-charts/copia:0.39.2-beta
Digest: sha256:138f810c803940827a8624777d5aec8eae9b312ed2ef13d0b3402e94bb123002
Error: failed pre-install: 1 error occurred:
	* timed out waiting for the condition
```