### PR TITLE
[CU-86a72bg60] Update Copia self-hosted to 0.39.0

### DIFF
--- a/charts/copia/Changelog.md
+++ b/charts/copia/Changelog.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 0.43.0 
+
+**Release date:** 2025-03-04
+
+![AppVersion: v0.39.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.39.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Self-hosted release Copia v0.39.0 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.42.0 
 
 **Release date:** 2025-02-06

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.42.0
-appVersion: v0.38.0
+version: 0.43.0
+appVersion: v0.39.0
 cmVersion: v0.1.0


### PR DESCRIPTION
Upgrade the helm chart to reflect the new self-hosted release. Directly copied the approach of https://github.com/copia-automation/helm-charts/pull/93