### PR TITLE
Helm release 0.44.0 for Copia self-hosted 0.41.0

### DIFF
--- a/charts/copia/Changelog.md
+++ b/charts/copia/Changelog.md
@@ -1,11 +1,14 @@
 # Change Log
 
-## Next Release 
+## 0.44.0 
 
-![AppVersion: v0.39.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.39.0&color=success&logo=)
+**Release date:** 2025-04-02
+
+![AppVersion: v0.41.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.39.0&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
+* Self-hosted release Copia v0.41.0 
 * Trigger a deployment rollout on configmap or secret changes 
 
 ### Default value changes

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.43.1
-appVersion: v0.39.0
+version: 0.44.0
+appVersion: v0.41.0
 cmVersion: v0.1.0


### PR DESCRIPTION
Update Copia helm chart to 0.41.0.