### PR TITLE
conversion-manager v0.1.10

### DIFF
--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -142,7 +142,7 @@ copia:
   #     LICENSE_KEY: <REQUIRED>
 
 #Conversion manager service configuration
-cmVersion: v0.1.7
+cmVersion: v0.1.10
 conversion_manager_service:
   enabled: false
   deployment:


### PR DESCRIPTION
sets default conversion manager version to v0.1.10 in helm chart