### PR TITLE
[CU-86ag4wgug] Update Charts version to v0.56.0 and Copia appVersion to v0.53.0

### DIFF
--- a/charts/copia/Changelog.md
+++ b/charts/copia/Changelog.md
@@ -1,14 +1,30 @@
 # Change Log
 
+## 0.56.0 
+
+**Release date:** 2026-03-13
+
+![AppVersion: v0.53.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.53.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Bump copia chart and app versions 
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.55.0 
 
-**Release date:** 2026-03-05
+**Release date:** 2026-03-06
 
 ![AppVersion: v0.52.0](https://img.shields.io/static/v1?label=AppVersion&message=v0.52.0&color=success&logo=)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
-* Bump copia chart to 0.55.0 and app v0.52.0 
+* [CU-86afpkemn] Update copia appVersion to v0.52.0 (#131) 
 
 ### Default value changes
 

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.55.0
-appVersion: v0.52.0
+version: 0.56.0
+appVersion: v0.53.0


### PR DESCRIPTION
<!-- This is a guideline -->

## Description
<!-- Please provide a brief description of the changes being made -->
This pull request updates the Copia Helm chart to a new version. The change is bumping both the chart and application versions to keep them in sync with the latest release. 
Version updates:

* Bumped `version` in `charts/copia/Chart.yaml` from `0.55.0` to `0.56.0` and `appVersion` from `v0.52.0` to `v0.53.0` to reflect the new release.
* Added a new section to `charts/copia/Changelog.md` for version `0.56.0`, documenting the version bump and confirming no default value changes.
## Checklist
<!-- Please place an "x" between brackets to mark each relevant box -->

<!-- This Pull Request ... -->
- [x] Links to Project Management Tool
- [x] Has the appropriate PR type label (bug, feature, testing, etc.)
- [ ] Introduces new tests on the code paths changed
- [ ] Has been manually verified
- [ ] Generates no new console or log warnings/errors (manual check)
- [ ] Documentation added/updated as applicable

## Testing Description
<!-- Please provide a brief description of the type of testing done as applicable -->

<!-- If relevant, please include before and after screenshots or videos of any UI/UX, data-contract, testing or other changes -->
### Before

### After
