### PR TITLE
Run format check on all PRs [ENG-15498]

### DIFF
--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -2,9 +2,6 @@ name: Check Format
 
 on:
   pull_request:
-    paths:
-      - '**.yaml'
-      - '**.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

This PR removes the path filter from the Check Format workflow so that it runs on every pull request rather than only on PRs that touch YAML files. It is prep work for a [companion change in platform-tng](https://github.com/copia-automation/platform-tng/pull/2337) that will make the format check required for merging helm-charts PRs. A required status check has to report on every PR for GitHub to consider the PR mergeable, so if the workflow skips PRs that don't touch YAML, those PRs would be blocked forever waiting on a check that never runs. The workflow still uses an internal paths filter to skip the Prettier step itself when no YAML changed.