### PR TITLE
Cancel in-progress runs for require-pr-label

### DIFF
--- a/.github/workflows/require-pr-label.yaml
+++ b/.github/workflows/require-pr-label.yaml
@@ -7,6 +7,15 @@ on:
 permissions:
   pull-requests: read
 
+# Cancel an in-progress run when a newer event for the same PR arrives. This
+# resolves the race where an automation (e.g. peter-evans/create-pull-request)
+# opens a PR, firing `opened` with empty labels, and then immediately calls
+# the addLabels API, firing `labeled`. The `labeled` run cancels the `opened`
+# run so the rollup reflects the latest state.
+concurrency:
+  group: require-pr-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `concurrency: cancel-in-progress: true` to `require-pr-label.yaml`, keyed on PR number
- Resolves the failed-check-label-run that appears on PRs opened by automation (e.g. helm chart appVersion bumps from gitea-fork)

## Why
GitHub's API requires labels to be applied via a separate call after PR creation; `peter-evans/create-pull-request` does this. The `opened` event fires before the follow-up `addLabels` call, so its payload captures `labels: []` and freezes that on the workflow run. The check runs and fails with no labels; re-running uses the same captured payload, so it can never succeed (verified by reading run #25132055493's logs: `env: LABELS: []` even on a re-run 24h later).

With this change, when the subsequent `labeled` event queues its run, the older `opened` run is cancelled in flight. The latest non-cancelled run is the `labeled` one with the correct payload, so the rollup reports success.