### PR TITLE
Fix Changelog.md generation in release workflow

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set `version` in Chart.yaml to ${{ inputs.version }}
         if: inputs.version != ''
         run: |
-          sed -i "s/version: 0.0.0/version: ${{ inputs.version }}/" charts/copia/Chart.yaml
+          sed -i "s/^version: .*/version: ${{ inputs.version }}/" charts/copia/Chart.yaml
           # helm-changelog reads Chart.yaml via `git cat-file`, not the worktree,
           # so the version bump must be a real (local-only) commit to be visible.
           git -c user.name="github-actions[bot]" \

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -44,6 +44,11 @@ jobs:
         if: inputs.version != ''
         run: |
           sed -i "s/version: 0.0.0/version: ${{ inputs.version }}/" charts/copia/Chart.yaml
+          # helm-changelog reads Chart.yaml via `git cat-file`, not the worktree,
+          # so the version bump must be a real (local-only) commit to be visible.
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -am "Release copia-${{ inputs.version }}"
 
       - name: Generate Helm changelog
         run: docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -v "$(pwd):/data" mogensen/helm-changelog:latest

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -53,6 +53,19 @@ jobs:
       - name: Generate Helm changelog
         run: docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -v "$(pwd):/data" mogensen/helm-changelog:latest
 
+      # Historical commits af65307 (#141) and 0f613e0 (#150) committed
+      # `version: 0.0.0`, which helm-changelog surfaces as a `## 0.0.0` section
+      # on every run. Strip it; match `0.0.0` exactly to avoid catching
+      # `0.0.0-beta.pr<n>` from beta builds.
+      - name: Strip phantom `## 0.0.0` section from Changelog.md
+        run: |
+          awk '
+            /^## 0\.0\.0[[:space:]]*$/ { skip=1; next }
+            /^## / && skip             { skip=0 }
+            !skip
+          ' charts/copia/Changelog.md > charts/copia/Changelog.md.tmp
+          mv charts/copia/Changelog.md.tmp charts/copia/Changelog.md
+
       - name: Package Helm chart
         run: helm package ./charts/copia
 

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.58.0
+version: 0.0.0 # placeholder - set during release
 appVersion: v0.55.0

--- a/charts/copia/Chart.yaml
+++ b/charts/copia/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: copia
 description: Copia Helm chart for Kubernetes
 type: application
-version: 0.0.0 # placeholder - set during release
+version: 0.58.0
 appVersion: v0.55.0


### PR DESCRIPTION
Fixes an issue where publishing a release caused the helm chart's changelog to contain an entry for a phantom version 0.0.0 and no entry for the chart version that was actually published (0.58.0 in the recent release):

<img width="1065" height="862" alt="Screenshot 2026-05-01 at 4 47 42 PM" src="https://github.com/user-attachments/assets/7bb6d73f-de74-4445-9f5e-39c9374eec41" />

The issue occurred because in https://github.com/copia-automation/helm-charts/pull/141 I committed a change to Chart.yaml that replaced the chart `version` with a `0.0.0` placeholder. The reasoning behind the placeholder is that the new release process derives the chart version from the release tag and renders the version into Chart.yaml before publishing the chart to the registry, so it is unnecessary to commit the new version to Chart.yaml on every release. However this conflicts with the way `mogensen/helm-changelog` works. `helm-changelog` generates the changelog by walking the commit history and adding an entry to the changelog for every commit that updated the chart version. Because I commited a change that set the chart version to 0.0.0, `helm-changelog` added a `0.0.0` entry to the changelog.

The issue of version 0.58.0 not appearing in the changelog was due to me rendering the new version into the chart at publish time rather than committing the new version before publishing. `helm-changelog` only checks the commit history for new chart versions and doesn't check the git index, so it didn't pick up the change from 0.0.0 to 0.58.0. The fix for this issue is to commit the version change from 0.0.0 to 0.58.0 locally before generating the changelog but not actually push the new version to main; that way the version in Chart.yaml remains at 0.0.0.

One downside of the 0.0.0 placeholder is that `helm-changelog` will always generate an entry in the changelog for a version 0.0.0 because 0.0.0 exists in the commit history. So this PR also adds a step to the release process that removes the 0.0.0 entry from the changelog after it is generated and before the chart is published.

## TODO

- [ ] Once this PR is merged, manually dispatch the publish-helm-chart.yaml workflow so that a new helm chart containing the corrected changelog is pushed to the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Helm chart publishing workflow to properly track version changes in Git history, ensuring version bumps are recorded for tools that rely on Git commit information.
  * Enhanced changelog generation filtering for more reliable artifact processing during releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/copia-automation/helm-charts/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->