### PR TITLE
Add post-install hook to create admin user

### DIFF
--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -37,20 +37,26 @@ data:
 
     SALT=$(head -c 10 /dev/urandom | base64 | tr -d '/+=' | head -c 10)
     HASH=$(printf '%s' "$ADMIN_PASSWORD" | argon2 "$SALT" -id -t 2 -m 16 -p 8 -l 50 | awk '/Hash:/ {print $2}')
+    AVATAR=$(head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 64)
 
-    psql <<SQL
+    psql \
+      -v admin_username="$ADMIN_USERNAME" \
+      -v admin_email="$ADMIN_EMAIL" \
+      -v hash="$HASH" \
+      -v salt="$SALT" \
+      -v avatar="$AVATAR" <<'SQL'
     INSERT INTO "user" (
       lower_name, name, full_name, email, passwd, passwd_hash_algo,
       type, salt, is_admin, is_active, created_unix, updated_unix,
       last_login_unix, email_notifications_preference, avatar, avatar_email
     ) VALUES (
-      lower('$ADMIN_USERNAME'), '$ADMIN_USERNAME', '$ADMIN_USERNAME',
-      '$ADMIN_EMAIL', '$HASH', 'argon2',
-      0, '$SALT', true, true,
+      lower(:'admin_username'), :'admin_username', :'admin_username',
+      :'admin_email', :'hash', 'argon2',
+      0, :'salt', true, true,
       extract(epoch from now())::bigint, extract(epoch from now())::bigint,
       0, 'enabled',
-      '$(head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 64)',
-      '$ADMIN_EMAIL'
+      :'avatar',
+      :'admin_email'
     );
     SQL
 

--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -1,0 +1,100 @@
+{{- if and .Values.adminUser .Values.adminUser.create }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}-admin-bootstrap-script
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  bootstrap.sh: |
+    #!/bin/sh
+    set -eu
+    apk add --no-cache argon2 >/dev/null
+
+    until pg_isready -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t 2; do
+      echo "waiting for postgres..."; sleep 2
+    done
+
+    until psql -tAc "SELECT 1 FROM information_schema.tables WHERE table_name='user'" | grep -q 1; do
+      echo "waiting for gitea schema..."; sleep 2
+    done
+
+    EXISTING=$(psql -tAc "SELECT COUNT(*) FROM \"user\" WHERE is_admin = true")
+    if [ "$EXISTING" -gt 0 ]; then
+      echo "admin already exists, skipping"; exit 0
+    fi
+
+    SALT=$(head -c 10 /dev/urandom | base64 | tr -d '/+=' | head -c 10)
+    HASH=$(printf '%s' "$ADMIN_PASSWORD" | argon2 "$SALT" -id -t 2 -m 16 -p 8 -l 50 | awk '/Hash:/ {print $2}')
+
+    psql <<SQL
+    INSERT INTO "user" (
+      lower_name, name, full_name, email, passwd, passwd_hash_algo,
+      type, salt, is_admin, is_active, created_unix, updated_unix,
+      last_login_unix, email_notifications_preference, avatar, avatar_email
+    ) VALUES (
+      lower('$ADMIN_USERNAME'), '$ADMIN_USERNAME', '$ADMIN_USERNAME',
+      '$ADMIN_EMAIL', '$HASH', 'argon2',
+      0, '$SALT', true, true,
+      extract(epoch from now())::bigint, extract(epoch from now())::bigint,
+      0, 'enabled',
+      '$(head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 64)',
+      '$ADMIN_EMAIL'
+    );
+    SQL
+
+    echo "admin user $ADMIN_USERNAME created"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "app.fullname" . }}-admin-bootstrap
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: postgres:15-alpine
+          command: ["/bin/sh", "/scripts/bootstrap.sh"]
+          env:
+            {{- $parts := splitList ":" .Values.copia.config.database.HOST }}
+            {{- $pgHost := index $parts 0 }}
+            {{- $pgPort := "5432" }}
+            {{- if eq (len $parts) 2 }}{{ $pgPort = index $parts 1 }}{{ end }}
+            - name: PGHOST
+              value: {{ $pgHost | quote }}
+            - name: PGPORT
+              value: {{ $pgPort | quote }}
+            - name: PGUSER
+              value: {{ .Values.copia.config.database.USER | quote }}
+            - name: PGDATABASE
+              value: {{ .Values.copia.config.database.NAME | quote }}
+            - name: PGPASSWORD
+              value: {{ .Values.copia.config.database.PASSWD | quote }}
+            - name: ADMIN_USERNAME
+              value: {{ .Values.adminUser.username | quote }}
+            - name: ADMIN_EMAIL
+              value: {{ .Values.adminUser.email | quote }}
+            - name: ADMIN_PASSWORD
+              value: {{ .Values.adminUser.password | quote }}
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+      volumes:
+        - name: script
+          configMap:
+            name: {{ include "app.fullname" . }}-admin-bootstrap-script
+            defaultMode: 0755
+{{- end }}

--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -40,6 +40,7 @@ data:
     AVATAR=$(head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 64)
 
     psql \
+      -v ON_ERROR_STOP=1 \
       -v admin_username="$ADMIN_USERNAME" \
       -v admin_email="$ADMIN_EMAIL" \
       -v hash="$HASH" \

--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -48,16 +48,15 @@ data:
       -v avatar="$AVATAR" <<'SQL'
     INSERT INTO "user" (
       lower_name, name, full_name, email, passwd, passwd_hash_algo,
-      type, salt, is_admin, is_active, created_unix, updated_unix,
-      last_login_unix, email_notifications_preference, avatar, avatar_email
+      type, salt, is_admin, is_active, must_change_password,
+      created_unix, updated_unix, last_login_unix,
+      email_notifications_preference, avatar, avatar_email
     ) VALUES (
       lower(:'admin_username'), :'admin_username', :'admin_username',
       :'admin_email', :'hash', 'argon2',
-      0, :'salt', true, true,
-      extract(epoch from now())::bigint, extract(epoch from now())::bigint,
-      0, 'enabled',
-      :'avatar',
-      :'admin_email'
+      0, :'salt', true, true, true,
+      extract(epoch from now())::bigint, extract(epoch from now())::bigint, 0,
+      'enabled', :'avatar', :'admin_email'
     );
     SQL
 

--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -15,11 +15,18 @@ data:
     set -eu
     apk add --no-cache argon2 >/dev/null
 
+    max_attempts=120
+    attempt=0
     until pg_isready -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t 2; do
+      attempt=$((attempt + 1))
+      [ "$attempt" -ge "$max_attempts" ] && echo "postgres readiness timeout" && exit 1
       echo "waiting for postgres..."; sleep 2
     done
 
+    attempt=0
     until psql -tAc "SELECT 1 FROM information_schema.tables WHERE table_name='user'" | grep -q 1; do
+      attempt=$((attempt + 1))
+      [ "$attempt" -ge "$max_attempts" ] && echo "gitea schema timeout" && exit 1
       echo "waiting for gitea schema..."; sleep 2
     done
 
@@ -60,6 +67,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
+  activeDeadlineSeconds: 900
   ttlSecondsAfterFinished: 600
   template:
     spec:

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -828,6 +828,32 @@
           "type": "string"
         }
       }
+    },
+    "adminUser": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Bootstrap an initial admin user via a post-install Helm hook.",
+      "required": ["create"],
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "When true, run the post-install Job that creates an admin user in the database."
+        },
+        "username": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "password": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "if":   { "properties": { "create": { "const": true } } },
+      "then": { "required": ["username", "email", "password"] }
     }
   }
 }


### PR DESCRIPTION
Adds a helm post-install hook that inserts an admin user into the Copia postgres database if one doesn't already exist. The hook runs on every install and update. 

Users can configure the admin user's email address, username, and password via a new `adminUser` section in values.yaml. If `adminUser.create` is false, the admin user is not created during post-install.

Under the hood, the post-install hook first creates a ConfigMap containing the shell script that inserts the user into the DB. Then it runs a k8s Job that mounts the ConfigMap as a volume and executes it. 

I tested these changes locally against a minikube cluster consisting of one Copia pod and one Bitnami postgres pod. I verified that the admin user is created if one doesn't exist, and that the admin user credentials aren't rendered into the chart if `create == false`. 

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic admin user bootstrap during install/upgrade via a new adminUser.create setting (requires username, email, password when enabled). The bootstrap validates DB connectivity, waits for the user table, skips creation if an admin exists, securely creates a hashed admin account otherwise, and includes retries and cleanup for transient failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->