### PR TITLE
ENG 18577 Pre Generate Gitea Secrets

### DIFF
--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -48,8 +48,10 @@ spec:
       securityContext:
         fsGroup: 1000
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
-      {{- if and .Values.copia.config .Values.deployment.preflight }}
+      {{- $autoGen := and (hasKey .Values.copia "config") (and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled) }}
+      {{- if or (and .Values.copia.config .Values.deployment.preflight) $autoGen }}
       initContainers:
+        {{- if and .Values.copia.config .Values.deployment.preflight }}
         - name: {{ .Chart.Name }}-init
           image: postgres:latest
           imagePullPolicy: Always
@@ -70,6 +72,29 @@ spec:
               value: {{ .Values.copia.config.database.PASSWD }}
             - name: PGDATABASE
               value: {{ .Values.copia.config.database.NAME }}
+        {{- end }}
+        {{- if $autoGen }}
+        - name: render-app-ini
+          image: alpine:3.22
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              cp /tmp/template/app.ini /tmp/final/app.ini
+              for key in SECRET_KEY JWT_SECRET LFS_JWT_SECRET INTERNAL_TOKEN USER_SECRETS_PUBLIC_KEY USER_SECRETS_PRIVATE_KEY; do
+                if [ -f "/tmp/secrets/$key" ]; then
+                  val=$(cat "/tmp/secrets/$key")
+                  sed -i "s|###${key}###|${val}|g" /tmp/final/app.ini
+                fi
+              done
+          volumeMounts:
+            - name: app-ini-template
+              mountPath: /tmp/template
+            - name: gitea-secrets
+              mountPath: /tmp/secrets
+            - name: config
+              mountPath: /tmp/final
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -175,8 +200,20 @@ spec:
       volumes:
         {{- if (hasKey .Values.copia "config") }}
         - name: config
+          {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+          emptyDir: {}
+          {{- else }}
           secret:
             secretName: {{ include "app.fullname" . }}-ini
+          {{- end }}
+        {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+        - name: app-ini-template
+          secret:
+            secretName: {{ include "app.fullname" . }}-ini
+        - name: gitea-secrets
+          secret:
+            secretName: {{ include "app.fullname" . }}-gitea-secrets
+        {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/copia/templates/copia-secret.yaml
+++ b/charts/copia/templates/copia-secret.yaml
@@ -9,7 +9,29 @@ type: Opaque
 stringData:
   app.ini: |
     {{- /* autogenerate app.ini */ -}}
-    {{- range $key, $value := .Values.copia.config  }}
+    {{- $autoGen := and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled -}}
+    {{- $cfg := deepCopy .Values.copia.config -}}
+    {{- if $autoGen -}}
+      {{- $autoGenKeys := list
+            (list "security" "INTERNAL_TOKEN")
+            (list "security" "SECRET_KEY")
+            (list "oauth2"   "JWT_SECRET")
+            (list "server"   "LFS_JWT_SECRET")
+            (list "copia"    "USER_SECRETS_PUBLIC_KEY")
+            (list "copia"    "USER_SECRETS_PRIVATE_KEY") -}}
+      {{- range $pair := $autoGenKeys -}}
+        {{- $section := index $pair 0 -}}
+        {{- $key := index $pair 1 -}}
+        {{- if not (hasKey $cfg $section) -}}
+          {{- $_ := set $cfg $section dict -}}
+        {{- end -}}
+        {{- $sectionMap := index $cfg $section -}}
+        {{- if not (index $sectionMap $key) -}}
+          {{- $_ := set $sectionMap $key (printf "###%s###" $key) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- range $key, $value := $cfg }}
     {{- if kindIs "map" $value }}
     {{- if gt (len $value) 0 }}
 

--- a/charts/copia/templates/gitea-secrets-hook.yaml
+++ b/charts/copia/templates/gitea-secrets-hook.yaml
@@ -104,8 +104,17 @@ spec:
             - |
               set -eu
               apk add --no-cache ca-certificates kubectl > /dev/null
-              if kubectl get secret {{ include "app.fullname" . }}-gitea-secrets -n {{ .Release.Namespace }} > /dev/null 2>&1; then
-                echo "secret already exists, preserving existing values"
+              SECRET_NAME={{ include "app.fullname" . }}-gitea-secrets
+              NAMESPACE={{ .Release.Namespace }}
+              if kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" > /dev/null 2>&1; then
+                for key in SECRET_KEY JWT_SECRET LFS_JWT_SECRET INTERNAL_TOKEN USER_SECRETS_PUBLIC_KEY USER_SECRETS_PRIVATE_KEY; do
+                  val=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o "jsonpath={.data.${key}}" 2>/dev/null)
+                  if [ -z "$val" ]; then
+                    echo "existing $SECRET_NAME is missing required key: $key" >&2
+                    exit 1
+                  fi
+                done
+                echo "secret already exists with all required keys, preserving existing values"
                 exit 0
               fi
               kubectl apply -f /tmp/work/secret.yaml

--- a/charts/copia/templates/gitea-secrets-hook.yaml
+++ b/charts/copia/templates/gitea-secrets-hook.yaml
@@ -1,0 +1,119 @@
+{{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.fullname" . }}-gitea-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "app.fullname" . }}-gitea-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "app.fullname" . }}-gitea-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "app.fullname" . }}-gitea-secrets-init
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "app.fullname" . }}-gitea-secrets-init
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "app.fullname" . }}-gitea-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "app.fullname" . }}-gitea-secrets-init
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: generate
+          image: "{{ include "app.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              SECRET_KEY=$(gitea generate secret SECRET_KEY 2>/dev/null)
+              JWT_SECRET=$(gitea generate secret JWT_SECRET 2>/dev/null)
+              LFS_JWT_SECRET=$JWT_SECRET
+              INTERNAL_TOKEN=$(gitea generate secret INTERNAL_TOKEN 2>/dev/null)
+              USER_SECRET=$(gitea generate secret CRYPTO_ANON_KEYS 2>/dev/null)
+              USER_PUBLIC=$(echo "$USER_SECRET"  | sed -n 's/^public: *//p')
+              USER_PRIVATE=$(echo "$USER_SECRET" | sed -n 's/^private: *//p')
+              cat > /tmp/work/secret.yaml <<EOF
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: {{ include "app.fullname" . }}-gitea-secrets
+                namespace: {{ .Release.Namespace }}
+              type: Opaque
+              stringData:
+                SECRET_KEY: $SECRET_KEY
+                JWT_SECRET: $JWT_SECRET
+                LFS_JWT_SECRET: $LFS_JWT_SECRET
+                INTERNAL_TOKEN: $INTERNAL_TOKEN
+                USER_SECRETS_PUBLIC_KEY: $USER_PUBLIC
+                USER_SECRETS_PRIVATE_KEY: $USER_PRIVATE
+              EOF
+          volumeMounts:
+            - name: work
+              mountPath: /tmp/work
+      containers:
+        - name: apply
+          image: alpine:3.22
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              apk add --no-cache ca-certificates kubectl > /dev/null
+              if kubectl get secret {{ include "app.fullname" . }}-gitea-secrets -n {{ .Release.Namespace }} > /dev/null 2>&1; then
+                echo "secret already exists, preserving existing values"
+                exit 0
+              fi
+              kubectl apply -f /tmp/work/secret.yaml
+              echo "gitea-secrets Secret created"
+          volumeMounts:
+            - name: work
+              mountPath: /tmp/work
+      volumes:
+        - name: work
+          emptyDir: {}
+{{- end }}

--- a/charts/copia/tests/copia_secret_test.yaml
+++ b/charts/copia/tests/copia_secret_test.yaml
@@ -16,6 +16,7 @@ tests:
           pattern: copia-ini
   - it: Test Secret given values
     set:
+      chartGeneratedSecrets.enabled: false
       copia.config.APP_NAME: Copia
       copia.config.RUN_MODE: production
       copia.config.server.SSH_PORT: 22
@@ -32,6 +33,7 @@ tests:
               SSH_PORT = 22
   - it: Test Secret full values
     set:
+      chartGeneratedSecrets.enabled: false
       copia.config.APP_NAME: Copia
       copia.config.RUN_MODE: production
       copia.config.RUN_USER: root
@@ -166,3 +168,54 @@ tests:
 
               [session]
               PROVIDER = file
+  - it: Test Secret with auto-gen enabled and no user secrets — all six placeholders rendered
+    set:
+      chartGeneratedSecrets.enabled: true
+      copia.config.APP_NAME: Copia
+      copia.config.server.HTTP_PORT: 4001
+    asserts:
+      - equal:
+          path: stringData["app.ini"]
+          value: |
+              APP_NAME = Copia
+
+              [copia]
+              USER_SECRETS_PRIVATE_KEY = ###USER_SECRETS_PRIVATE_KEY###
+              USER_SECRETS_PUBLIC_KEY = ###USER_SECRETS_PUBLIC_KEY###
+
+              [oauth2]
+              JWT_SECRET = ###JWT_SECRET###
+
+              [security]
+              INTERNAL_TOKEN = ###INTERNAL_TOKEN###
+              SECRET_KEY = ###SECRET_KEY###
+
+              [server]
+              HTTP_PORT = 4001
+              LFS_JWT_SECRET = ###LFS_JWT_SECRET###
+  - it: Test Secret with auto-gen enabled and user-supplied INTERNAL_TOKEN — literal wins, others placeholder
+    set:
+      chartGeneratedSecrets.enabled: true
+      copia.config.APP_NAME: Copia
+      copia.config.server.HTTP_PORT: 4001
+      copia.config.security.INTERNAL_TOKEN: literaltoken
+    asserts:
+      - equal:
+          path: stringData["app.ini"]
+          value: |
+              APP_NAME = Copia
+
+              [copia]
+              USER_SECRETS_PRIVATE_KEY = ###USER_SECRETS_PRIVATE_KEY###
+              USER_SECRETS_PUBLIC_KEY = ###USER_SECRETS_PUBLIC_KEY###
+
+              [oauth2]
+              JWT_SECRET = ###JWT_SECRET###
+
+              [security]
+              INTERNAL_TOKEN = literaltoken
+              SECRET_KEY = ###SECRET_KEY###
+
+              [server]
+              HTTP_PORT = 4001
+              LFS_JWT_SECRET = ###LFS_JWT_SECRET###

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -829,6 +829,17 @@
         }
       }
     },
+    "chartGeneratedSecrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "When enabled, the chart pre-generates Gitea internal secrets via a pre-install Job and assembles them into app.ini at Pod startup via an init container.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
     "adminUser": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -1,12 +1,15 @@
 #Copia configuration
 replicaCount: 1
 clusterDomain: cluster.local
-# When enabled (default), the chart generates Gitea internal secrets via a
-# pre-install Job and assembles them into app.ini at Pod startup via an init
-# container. Set to false when an upstream system (e.g. Flux valuesFrom) is
-# already supplying the values via copia.config.*.
+# When enabled, the chart generates Gitea internal secrets (SECRET_KEY,
+# JWT_SECRET, LFS_JWT_SECRET, INTERNAL_TOKEN, USER_SECRETS_PUBLIC_KEY,
+# USER_SECRETS_PRIVATE_KEY) via a pre-install Job and assembles them into
+# app.ini at Pod startup via an init container. Off by default for backward
+# compatibility with consumers that already supply these via copia.config.*
+# (e.g. Flux valuesFrom). Set to true for plain `helm install` to skip the
+# manual secret-generation step.
 chartGeneratedSecrets:
-  enabled: true
+  enabled: false
 #Use this value "*copia_port" to reference the value of the copia_server_http_port when setting HTTP_PORT on the copia config.
 copia_server_http_port: &copia_port 4001
 conversion_manager_http_port: &cm_port 8888

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -1,6 +1,12 @@
 #Copia configuration
 replicaCount: 1
 clusterDomain: cluster.local
+# When enabled (default), the chart generates Gitea internal secrets via a
+# pre-install Job and assembles them into app.ini at Pod startup via an init
+# container. Set to false when an upstream system (e.g. Flux valuesFrom) is
+# already supplying the values via copia.config.*.
+chartGeneratedSecrets:
+  enabled: true
 #Use this value "*copia_port" to reference the value of the copia_server_http_port when setting HTTP_PORT on the copia config.
 copia_server_http_port: &copia_port 4001
 conversion_manager_http_port: &cm_port 8888


### PR DESCRIPTION
Adds pre-install hooks to the helm chart that generates the gitea secrets and renders them into app.ini so that we no longer need to rely on Flux. The way the new pre-install hooks work is:

1. values.yaml has a new optional config, `chartGeneratedSecrets.enabled`. When `true`, a pre-install hook is rendered into the chart.
2. The pre-install hook runs an init container that uses the gitea binary to generate the secrets, then writes the secrets to a new k8s secret called `copia-gitea-secrets`
3. The original `copia-ini` secret has been modified so that the secret keys (such as `security.INTERNAL_TOKEN`) are replaced with empty placeholders when the k8s secret is created
4. The Copia deployment's init container merges copia-gitea-secrets into copia-ini, replacing the placeholders with the real secret values

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added optional automatic generation of internal application secrets during deployment
  * New `chartGeneratedSecrets.enabled` configuration option enables simplified deployments without requiring pre-configured secrets
  * Application configuration is now dynamically assembled at deployment time when auto-generation is enabled

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/copia-automation/helm-charts/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->