### PR TITLE
Add topologySpreadConstraints to helm chart

### DIFF
--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -193,6 +193,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -441,6 +441,9 @@
       "type": "object",
       "additionalProperties": true
     },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
     "service": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -62,6 +62,7 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: []
 deployment:
   preflight: false
   configmap:


### PR DESCRIPTION
Updates the helm chart to add support for `topologySpreadConstraints` so that we can distribute pods across nodes and/or AZs in HA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring topology spread constraints to control pod distribution across cluster nodes, enabling better resource utilization and improved application availability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/copia-automation/helm-charts/pull/156)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->