### PR TITLE
Add topology spread constraints to conversion manager

### DIFF
--- a/charts/copia/templates/conversion-manager-deployment.yaml
+++ b/charts/copia/templates/conversion-manager-deployment.yaml
@@ -88,6 +88,10 @@ spec:
       affinity:
         {{- toYaml .Values.conversion_manager_service.deployment.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.conversion_manager_service.deployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.conversion_manager_service.deployment.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.conversion_manager_service.deployment.tolerations }}
       tolerations:
         {{- toYaml .Values.conversion_manager_service.deployment.tolerations | nindent 8 }}

--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -193,6 +193,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -441,6 +441,9 @@
       "type": "object",
       "additionalProperties": true
     },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
     "service": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -221,6 +221,9 @@
             "affinity": {
               "type": "object",
               "additionalProperties": true
+            },
+            "topologySpreadConstraints": {
+              "type": "array"
             }
           }
         },

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -62,6 +62,7 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: []
 deployment:
   preflight: false
   configmap:

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -191,6 +191,7 @@ conversion_manager_service:
     readinessProbe: {}
     nodeSelector: {}
     affinity: {}
+    topologySpreadConstraints: []
     tolerations: []
     volumeMounts: []
     volumes: []


### PR DESCRIPTION
Adds optional `topologySpreadConstraints` to the conversion manager deployment

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>