### PR TITLE
remove conversion-manager DATABASE_URL

### DIFF
--- a/charts/copia/tests/conversion_manager_configmap_test.yaml
+++ b/charts/copia/tests/conversion_manager_configmap_test.yaml
@@ -48,8 +48,5 @@ tests:
           path: data.DB_HOST
           value: "localhost:5441"
       - equal:
-          path: data.DATABASE_URL
-          value: "postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/${DB_NAME}?schema=public"
-      - equal:
           path: data.ENABLE_HTTPS
           value: "false"

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -331,7 +331,7 @@
         "configmap": {
           "type": "object",
           "additionalProperties": true,
-          "required": ["DATABASE_URL","DB_USER","DB_HOST","COPIA_TEAM_ID","COPIA_USER_ID","ADMIN_ID","HOST","PORT","NODE_ENV","LOGGER_LEVEL","ENABLE_HTTPS"],
+          "required": ["DB_USER","DB_HOST","COPIA_TEAM_ID","COPIA_USER_ID","ADMIN_ID","HOST","PORT","NODE_ENV","LOGGER_LEVEL","ENABLE_HTTPS"],
           "properties": {
             "LOGGER_LEVEL": {
               "type": "string"
@@ -358,9 +358,6 @@
               "type": "string"
             },
             "DB_HOST": {
-              "type": "string"
-            },
-            "DATABASE_URL": {
               "type": "string"
             },
             "CERT_FILE": {

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -241,7 +241,6 @@ conversion_manager_service:
     DB_USER: postgres
     DB_HOST: localhost:5441
     DB_NAME: conversion_manager
-    DATABASE_URL: "postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/${DB_NAME}?schema=public"
     ENABLE_HTTPS: false
   secret:
     DB_PASSWORD: password


### PR DESCRIPTION
```
$ kubectl describe configmap conversion-manager-configmap -n copia | grep -A3 DATABASE_URL
DATABASE_URL:
----
postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/${DB_NAME}?schema=public
```

DATABASE_URL was not being set properly. I think it makes more sense to construct this string in the application code rather than try to set it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration settings to streamline deployment setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/copia-automation/helm-charts/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->