### PR TITLE
Generate conversion-manager secrets in a Helm pre-install hook

### DIFF
--- a/charts/copia/templates/conversion-manager-deployment.yaml
+++ b/charts/copia/templates/conversion-manager-deployment.yaml
@@ -55,6 +55,10 @@ spec:
                 name: {{ include "app.conversion-manager.fullname" . }}-configmap
             - secretRef:
                 name: {{ include "app.conversion-manager.fullname" . }}-secret
+            {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+            - secretRef:
+                name: conversion-manager-secrets
+            {{- end }}
           env:
             {{- if .Values.conversion_manager_service.deployment.env }}
             {{- toYaml .Values.conversion_manager_service.deployment.env | nindent 12 }}

--- a/charts/copia/templates/conversion-manager-secret.yaml
+++ b/charts/copia/templates/conversion-manager-secret.yaml
@@ -1,4 +1,9 @@
 {{- if and .Values.conversion_manager_service.secret (eq .Values.conversion_manager_service.enabled true)}}
+{{- $secrets := deepCopy .Values.conversion_manager_service.secret -}}
+{{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+  {{- $_ := unset $secrets "MANAGEMENT_TOKEN" -}}
+  {{- $_ := unset $secrets "WORKER_TOKEN" -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +12,7 @@ metadata:
     {{- include "app.conversion-manager.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- range $key, $value := .Values.conversion_manager_service.secret }}
+  {{- range $key, $value := $secrets }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}

--- a/charts/copia/templates/conversion-manager-secrets-hook.yaml
+++ b/charts/copia/templates/conversion-manager-secrets-hook.yaml
@@ -1,0 +1,124 @@
+{{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+  labels: {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "app.fullname" . }}-conversion-manager-secrets-init
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: generate
+          image: alpine:3.22
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              gen() { tr -d '\n' < /proc/sys/kernel/random/uuid; }
+              MT=$(gen)
+              WT=$(gen)
+              umask 077
+              echo -n "$MT" > /tmp/work/MANAGEMENT_TOKEN
+              echo -n "$WT" > /tmp/work/WORKER_TOKEN
+              cat > /tmp/work/secret.yaml <<EOF
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: conversion-manager-secrets
+                namespace: {{ .Release.Namespace }}
+              type: Opaque
+              stringData:
+                MANAGEMENT_TOKEN: $MT
+                WORKER_TOKEN: $WT
+              EOF
+          volumeMounts:
+            - name: work
+              mountPath: /tmp/work
+      containers:
+        - name: apply
+          image: alpine:3.22
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              apk add --no-cache ca-certificates kubectl > /dev/null
+              SECRET_NAME=conversion-manager-secrets
+              NAMESPACE={{ .Release.Namespace }}
+              if ! kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" > /dev/null 2>&1; then
+                kubectl apply -f /tmp/work/secret.yaml
+                echo "Created $SECRET_NAME with MANAGEMENT_TOKEN and WORKER_TOKEN"
+                exit 0
+              fi
+              for key in MANAGEMENT_TOKEN WORKER_TOKEN; do
+                val=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o "jsonpath={.data.${key}}" 2>/dev/null || true)
+                if [ -z "$val" ]; then
+                  new=$(cat "/tmp/work/${key}")
+                  kubectl patch secret "$SECRET_NAME" -n "$NAMESPACE" --type=merge \
+                    -p "$(printf '{"stringData":{"%s":"%s"}}' "$key" "$new")"
+                  echo "Patched $SECRET_NAME: added $key"
+                fi
+              done
+              echo "Secret $SECRET_NAME: token keys present (created or already satisfied)"
+          volumeMounts:
+            - name: work
+              mountPath: /tmp/work
+      volumes:
+        - name: work
+          emptyDir: {}
+{{- end }}

--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -81,17 +81,23 @@ spec:
             - |
               set -eu
               cp /tmp/template/app.ini /tmp/final/app.ini
-              for key in SECRET_KEY JWT_SECRET LFS_JWT_SECRET INTERNAL_TOKEN USER_SECRETS_PUBLIC_KEY USER_SECRETS_PRIVATE_KEY; do
-                if [ -f "/tmp/secrets/$key" ]; then
-                  val=$(cat "/tmp/secrets/$key")
-                  sed -i "s|###${key}###|${val}|g" /tmp/final/app.ini
-                fi
+              for dir in /tmp/secrets /tmp/cm-secrets; do
+                [ -d "$dir" ] || continue
+                for f in "$dir"/*; do
+                  [ -e "$f" ] || continue
+                  key=$(basename "$f")
+                  val=$(cat "$f")
+                  esc=$(printf '%s' "$val" | sed -e 's/[\\/&]/\\&/g')
+                  sed -i "s|###${key}###|${esc}|g" /tmp/final/app.ini
+                done
               done
           volumeMounts:
             - name: app-ini-template
               mountPath: /tmp/template
             - name: gitea-secrets
               mountPath: /tmp/secrets
+            - name: conversion-manager-secrets
+              mountPath: /tmp/cm-secrets
             - name: config
               mountPath: /tmp/final
         {{- end }}
@@ -217,6 +223,9 @@ spec:
         - name: gitea-secrets
           secret:
             secretName: {{ include "app.fullname" . }}-gitea-secrets
+        - name: conversion-manager-secrets
+          secret:
+            secretName: conversion-manager-secrets
         {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}

--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -86,9 +86,26 @@ spec:
                 for f in "$dir"/*; do
                   [ -e "$f" ] || continue
                   key=$(basename "$f")
-                  val=$(cat "$f")
-                  esc=$(printf '%s' "$val" | sed -e 's/[\\/&]/\\&/g')
-                  sed -i "s|###${key}###|${esc}|g" /tmp/final/app.ini
+                  awk -v ph="###${key}###" -v file="$f" '
+                    BEGIN {
+                      val = ""; first = 1
+                      while ((getline line < file) > 0) {
+                        if (first) { val = line; first = 0 }
+                        else { val = val "\n" line }
+                      }
+                      close(file)
+                    }
+                    {
+                      out = ""; rest = $0; idx = index(rest, ph)
+                      while (idx > 0) {
+                        out = out substr(rest, 1, idx - 1) val
+                        rest = substr(rest, idx + length(ph))
+                        idx = index(rest, ph)
+                      }
+                      print out rest
+                    }
+                  ' /tmp/final/app.ini > /tmp/final/app.ini.tmp
+                  mv /tmp/final/app.ini.tmp /tmp/final/app.ini
                 done
               done
           volumeMounts:

--- a/charts/copia/templates/copia-secret.yaml
+++ b/charts/copia/templates/copia-secret.yaml
@@ -13,12 +13,13 @@ stringData:
     {{- $cfg := deepCopy .Values.copia.config -}}
     {{- if $autoGen -}}
       {{- $autoGenKeys := list
-            (list "security" "INTERNAL_TOKEN")
-            (list "security" "SECRET_KEY")
-            (list "oauth2"   "JWT_SECRET")
-            (list "server"   "LFS_JWT_SECRET")
-            (list "copia"    "USER_SECRETS_PUBLIC_KEY")
-            (list "copia"    "USER_SECRETS_PRIVATE_KEY") -}}
+            (list "security"           "INTERNAL_TOKEN")
+            (list "security"           "SECRET_KEY")
+            (list "oauth2"             "JWT_SECRET")
+            (list "server"             "LFS_JWT_SECRET")
+            (list "copia"              "USER_SECRETS_PUBLIC_KEY")
+            (list "copia"              "USER_SECRETS_PRIVATE_KEY")
+            (list "conversion_manager" "MANAGEMENT_TOKEN") -}}
       {{- range $pair := $autoGenKeys -}}
         {{- $section := index $pair 0 -}}
         {{- $key := index $pair 1 -}}

--- a/charts/copia/tests/conversion_manager_deployment_test.yaml
+++ b/charts/copia/tests/conversion_manager_deployment_test.yaml
@@ -131,4 +131,28 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].key
           value: "dedicated"
+  - it: Test extra envFrom when chartGeneratedSecrets is enabled
+    set:
+      conversion_manager_service.enabled: true
+      chartGeneratedSecrets.enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: conversion-manager-secrets
+  - it: Test no extra envFrom when chartGeneratedSecrets is disabled
+    set:
+      conversion_manager_service.enabled: true
+      chartGeneratedSecrets.enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: conversion-manager-secrets
 

--- a/charts/copia/tests/conversion_manager_secret_test.yaml
+++ b/charts/copia/tests/conversion_manager_secret_test.yaml
@@ -35,3 +35,34 @@ tests:
       - equal:
           path: stringData.COPIA_TEAM_KEY
           value: "testCopiaTeamKey"
+  - it: Token keys are stripped when chartGeneratedSecrets is enabled
+    set:
+      conversion_manager_service.enabled: true
+      conversion_manager_service.secret.MANAGEMENT_TOKEN: should-not-appear-mt
+      conversion_manager_service.secret.WORKER_TOKEN: should-not-appear-wt
+      chartGeneratedSecrets.enabled: true
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.DB_PASSWORD
+          value: "password"
+      - notExists:
+          path: stringData.MANAGEMENT_TOKEN
+      - notExists:
+          path: stringData.WORKER_TOKEN
+  - it: Token keys are preserved when chartGeneratedSecrets is disabled
+    set:
+      conversion_manager_service.enabled: true
+      conversion_manager_service.secret.MANAGEMENT_TOKEN: keep-mt
+      conversion_manager_service.secret.WORKER_TOKEN: keep-wt
+      chartGeneratedSecrets.enabled: false
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.MANAGEMENT_TOKEN
+          value: "keep-mt"
+      - equal:
+          path: stringData.WORKER_TOKEN
+          value: "keep-wt"

--- a/charts/copia/tests/conversion_manager_secrets_hook_test.yaml
+++ b/charts/copia/tests/conversion_manager_secrets_hook_test.yaml
@@ -1,0 +1,110 @@
+suite: Test Conversion Manager Secrets pre-install hook
+templates:
+  - conversion-manager-secrets-hook.yaml
+tests:
+  - it: should render nothing when chartGeneratedSecrets is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ServiceAccount, Role, RoleBinding, and Job when enabled
+    set:
+      chartGeneratedSecrets.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: ServiceAccount has correct hook annotations
+    set:
+      chartGeneratedSecrets.enabled: true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - matchRegex:
+          path: metadata.name
+          pattern: conversion-manager-secrets-init$
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-20"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: Role grants secrets get/create/patch
+    set:
+      chartGeneratedSecrets.enabled: true
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: rules[0].apiGroups
+          value: [""]
+      - equal:
+          path: rules[0].resources
+          value: ["secrets"]
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "create", "patch"]
+
+  - it: RoleBinding binds the SA to the Role
+    set:
+      chartGeneratedSecrets.enabled: true
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - matchRegex:
+          path: subjects[0].name
+          pattern: conversion-manager-secrets-init$
+      - equal:
+          path: roleRef.kind
+          value: Role
+
+  - it: Job has correct hook weight and targets the legacy secret name
+    set:
+      chartGeneratedSecrets.enabled: true
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: alpine:3.22
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "name: conversion-manager-secrets"
+
+  - it: Job patches missing keys (idempotency branch present)
+    set:
+      chartGeneratedSecrets.enabled: true
+    documentIndex: 3
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "kubectl patch secret"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "MANAGEMENT_TOKEN"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "WORKER_TOKEN"

--- a/charts/copia/tests/copia_secret_test.yaml
+++ b/charts/copia/tests/copia_secret_test.yaml
@@ -168,7 +168,7 @@ tests:
 
               [session]
               PROVIDER = file
-  - it: Test Secret with auto-gen enabled and no user secrets — all six placeholders rendered
+  - it: Test Secret with auto-gen enabled and no user secrets — all placeholders rendered
     set:
       chartGeneratedSecrets.enabled: true
       copia.config.APP_NAME: Copia
@@ -178,6 +178,9 @@ tests:
           path: stringData["app.ini"]
           value: |
               APP_NAME = Copia
+
+              [conversion_manager]
+              MANAGEMENT_TOKEN = ###MANAGEMENT_TOKEN###
 
               [copia]
               USER_SECRETS_PRIVATE_KEY = ###USER_SECRETS_PRIVATE_KEY###
@@ -205,6 +208,9 @@ tests:
           value: |
               APP_NAME = Copia
 
+              [conversion_manager]
+              MANAGEMENT_TOKEN = ###MANAGEMENT_TOKEN###
+
               [copia]
               USER_SECRETS_PRIVATE_KEY = ###USER_SECRETS_PRIVATE_KEY###
               USER_SECRETS_PUBLIC_KEY = ###USER_SECRETS_PUBLIC_KEY###
@@ -214,6 +220,35 @@ tests:
 
               [security]
               INTERNAL_TOKEN = literaltoken
+              SECRET_KEY = ###SECRET_KEY###
+
+              [server]
+              HTTP_PORT = 4001
+              LFS_JWT_SECRET = ###LFS_JWT_SECRET###
+  - it: Test Secret with auto-gen enabled and user-supplied MANAGEMENT_TOKEN — literal wins
+    set:
+      chartGeneratedSecrets.enabled: true
+      copia.config.APP_NAME: Copia
+      copia.config.server.HTTP_PORT: 4001
+      copia.config.conversion_manager.MANAGEMENT_TOKEN: literalmgmt
+    asserts:
+      - equal:
+          path: stringData["app.ini"]
+          value: |
+              APP_NAME = Copia
+
+              [conversion_manager]
+              MANAGEMENT_TOKEN = literalmgmt
+
+              [copia]
+              USER_SECRETS_PRIVATE_KEY = ###USER_SECRETS_PRIVATE_KEY###
+              USER_SECRETS_PUBLIC_KEY = ###USER_SECRETS_PUBLIC_KEY###
+
+              [oauth2]
+              JWT_SECRET = ###JWT_SECRET###
+
+              [security]
+              INTERNAL_TOKEN = ###INTERNAL_TOKEN###
               SECRET_KEY = ###SECRET_KEY###
 
               [server]

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -1,13 +1,18 @@
 #Copia configuration
 replicaCount: 1
 clusterDomain: cluster.local
-# When enabled, the chart generates Gitea internal secrets (SECRET_KEY,
-# JWT_SECRET, LFS_JWT_SECRET, INTERNAL_TOKEN, USER_SECRETS_PUBLIC_KEY,
-# USER_SECRETS_PRIVATE_KEY) via a pre-install Job and assembles them into
-# app.ini at Pod startup via an init container. Off by default for backward
-# compatibility with consumers that already supply these via copia.config.*
-# (e.g. Flux valuesFrom). Set to true for plain `helm install` to skip the
-# manual secret-generation step.
+# When enabled, the chart generates bootstrap secrets via pre-install Jobs:
+#   - Gitea internal secrets (SECRET_KEY, JWT_SECRET, LFS_JWT_SECRET,
+#     INTERNAL_TOKEN, USER_SECRETS_PUBLIC_KEY, USER_SECRETS_PRIVATE_KEY),
+#     assembled into app.ini at Pod startup via an init container.
+#   - Conversion-manager tokens (MANAGEMENT_TOKEN, WORKER_TOKEN), written
+#     into the `conversion-manager-secrets` Secret and consumed directly
+#     by the conversion-manager Deployment (extra envFrom) and the main
+#     copia app.ini (MANAGEMENT_TOKEN placeholder substitution).
+# Off by default for backward compatibility with consumers that already
+# supply these via copia.config.* / conversion_manager_service.secret.*
+# (e.g. Flux valuesFrom from externally managed Secrets). Set to true for
+# plain `helm install` to skip the manual secret-generation step.
 chartGeneratedSecrets:
   enabled: false
 #Use this value "*copia_port" to reference the value of the copia_server_http_port when setting HTTP_PORT on the copia config.


### PR DESCRIPTION
Today the `conversion-manager-secrets` Secret (`MANAGEMENT_TOKEN`, `WORKER_TOKEN`) is created outside the chart by a kustomize Job in nexus, and Flux reads those keys back into chart values via `valuesFrom`. That works for the Flux-managed deployment, but a plain `helm install` has no way to bootstrap the tokens; you have to create the Secret out of band first.

I added a conversion-manager equivalent of the existing `gitea-secrets-hook`, gated behind `chartGeneratedSecrets.enabled` (off by default, so nothing changes for current consumers). When enabled, a `pre-install,pre-upgrade` Job idempotently creates the `conversion-manager-secrets` Secret: it generates two UUID tokens, creates the Secret if it is absent, and otherwise patches only the keys that are missing so existing values survive upgrades. The structure (ServiceAccount/Role/RoleBinding at weight -20, Job at weight -10) and the generation logic mirror the gitea hook and the nexus kustomize Job it replaces.

Consumption follows the same pattern already used for gitea. The conversion-manager Deployment picks the tokens up through an extra `envFrom` secretRef, and the main copia app receives `MANAGEMENT_TOKEN` via app.ini placeholder substitution in the `render-app-ini` init container (the loop now also reads from a `conversion-manager-secrets` mount). The static conversion-manager secret drops `MANAGEMENT_TOKEN`/`WORKER_TOKEN` when the hook is enabled, so the generated Secret is the sole source and there are no duplicate keys.

Scope here is the helm chart only. The nexus kustomize Job, its RBAC, and the Flux `valuesFrom` wiring are intentionally left in place and will be retired separately once this is proven.

## Testing
- `helm lint`: clean
- `helm unittest`: 13 suites, 47 tests pass (new hook suite plus added cases for the deployment envFrom toggle, static-secret token stripping, and the app.ini placeholder/literal behavior)
- `helm template` with the flag off renders no hook docs; with it on, the SA/Role/RoleBinding/Job render, the conversion-manager Deployment gains the extra secretRef, the static secret omits the tokens, and copia's app.ini shows the `MANAGEMENT_TOKEN` placeholder wired to the `/tmp/cm-secrets` mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional auto-generation and injection of Conversion Manager tokens into deployments when enabled via chart settings; tokens are provisioned and mounted so the app receives placeholders or real values as configured.
* **Tests**
  * Added tests covering enabled/disabled generation, secret contents, and hook rendering/idempotency.
* **Documentation**
  * Clarified chart docs about the auto-generation behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->