### PR TITLE
ENG-19206: Add Distr base-values overlay

### DIFF
--- a/charts/copia/distr/values.base.yaml
+++ b/charts/copia/distr/values.base.yaml
@@ -1,0 +1,71 @@
+# Distr base-values overlay (self-hosted profile).
+#
+# ADR-ENG-19206 attaches this file to the Distr ApplicationVersion via
+# `base-values-file`. It is identical for every customer. Distr merges it UNDER
+# the per-target/customer values, then the agent's `helm install` merges the
+# result over the chart defaults in ../values.yaml.
+#
+# Rules (ADR-ENG-19206 / ENG-19207):
+#   - No `{{ .Secrets.* }}` / `{{ .LicenseKeys.* }}` references here. Distr renders
+#     templating only on the per-target layer; base values are read as plain YAML.
+#   - No image tags here. The tag resolves from the chart (appVersion for the web
+#     app, cmVersion for conversion-manager); pinning a tag would defeat the mirror.
+#   - Customer-supplied keys (database HOST/NAME/USER/PASSWD, server ROOT_URL/DOMAIN/
+#     SSH_DOMAIN, ingress hosts, adminUser, persistence.storageClassName) are set per
+#     target in Distr, not here.
+
+# --- Copia web app ---
+image:
+  # Repository only — tag comes from Chart.appVersion.
+  repository: registry.distr.sh/copia-test/copia-web-app-selfhosted-releases
+
+# The agent injects the Distr registry pull secret, so the chart references none.
+imagePullSecrets: []
+
+# Generate Gitea and conversion-manager bootstrap secrets on a fresh install.
+chartGeneratedSecrets:
+  enabled: true
+
+# Cluster-internal service; ingress/LoadBalancer is a per-customer concern.
+service:
+  http:
+    type: ClusterIP
+
+persistence:
+  enabled: true
+  size: 100Gi
+
+copia:
+  config:
+    APP_NAME: Copia
+    RUN_MODE: prod
+    server:
+      # Vendor-fixed container port; the customer adds ROOT_URL/DOMAIN/SSH_DOMAIN per target.
+      HTTP_PORT: 4001
+    security:
+      # Lock the install so the first run does not expose the setup wizard.
+      INSTALL_LOCK: true
+    service:
+      DISABLE_REGISTRATION: true
+    database:
+      DB_TYPE: postgres
+      SSL_MODE: require
+    storage:
+      # Open (ENG-19206 Phase 2): local PVC for the pilot; may move to object storage.
+      STORAGE_TYPE: local
+    # Per-target / generated (NOT set here):
+    #   server.{ROOT_URL,DOMAIN,SSH_DOMAIN}, database.{HOST,NAME,USER,PASSWD},
+    #   copia.LICENSE_KEY ({{ .LicenseKeys.copia }}), and the secrets that
+    #   chartGeneratedSecrets produces (oauth2.JWT_SECRET, security.INTERNAL_TOKEN, ...).
+
+# --- Conversion-manager (part of the offering; enable in base) ---
+conversion_manager_service:
+  enabled: true
+  deployment:
+    image:
+      # Repository only — tag comes from .Values.cmVersion.
+      repository: registry.distr.sh/copia-test/conversion-manager
+    imagePullSecrets: []
+  service:
+    http:
+      type: ClusterIP


### PR DESCRIPTION
This adds `charts/copia/distr/values.base.yaml`, the self-hosted profile that Distr attaches to the Copia ApplicationVersion as its `base-values-file` under ADR-ENG-19206. The overlay is identical for every customer; Distr merges it beneath the per-target values and the agent's `helm install` merges the result over the chart defaults.

The overlay repoints both images at the Distr registry by repository only, so the tags continue to resolve from the chart (`appVersion` for the web app, `cmVersion` for conversion-manager) and the image mirror stays the source of truth for tags. It empties `imagePullSecrets` so the agent injects the registry pull secret, enables `chartGeneratedSecrets` for fresh installs, sets both services to `ClusterIP`, and fixes the vendor `app.ini` settings (`INSTALL_LOCK`, `DISABLE_REGISTRATION`, `RUN_MODE`, the database profile, and local storage). Customer-supplied and templated keys are deliberately left out, because Distr renders secret and license templating only on the per-target layer and reads base values as plain YAML.

I verified the overlay with `helm template` three ways: the chart defaults still render, the overlay renders on its own and passes the chart's `values.schema.json`, and the overlay plus a representative per-target overlay renders. Rendering also confirmed both images resolve to `registry.distr.sh/copia-test/...` at the chart-derived tags.

While validating, I hit a latent chart issue: `copia-service.yaml` fails with a nil pointer when `copia.config` is set without a `server` section. The overlay avoids it by setting the vendor-fixed `HTTP_PORT`, and the guard itself is tracked separately.

Draft until the chart-publish and image-mirror work (PR #158) lands, since this overlay is consumed by the ApplicationVersion job that builds on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)