### PR TITLE
ENG-19207: Edge + production Distr publish, mirror, and CI guardrails

### DIFF
--- a/.github/workflows/mirror-containers-to-distr.yaml
+++ b/.github/workflows/mirror-containers-to-distr.yaml
@@ -1,7 +1,7 @@
 name: Mirror Copia images to Distr
 
-# Renders the chart, finds every ghcr.io/copia-automation image reference, checks Distr
-# for each destination tag, then runs a matrix job only for images that still need syncing.
+# Renders the chart with helm template, collects ghcr.io/copia-automation image refs,
+# checks Distr for each destination, then runs a matrix job only for images still missing.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/mirror-containers-to-distr.yaml
+++ b/.github/workflows/mirror-containers-to-distr.yaml
@@ -1,10 +1,14 @@
 name: Mirror Copia images to Distr
 
-# Copies the Copia web app and conversion-manager images referenced by the chart
-# from GHCR to registry.distr.sh (same layout as Distr console examples).
+# Renders the chart, finds every ghcr.io/copia-automation image reference, checks Distr
+# for each destination tag, then runs a matrix job only for images that still need syncing.
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'charts/copia/**'
+      - '.github/workflows/mirror-containers-to-distr.yaml'
   workflow_call:
     secrets:
       GHCR_TOKEN:
@@ -21,12 +25,15 @@ permissions:
   contents: read
 
 jobs:
-  mirror:
+  discover-sync-matrix:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       DISTR_REGISTRY_HOST: registry.distr.sh
       DISTR_NAMESPACE: copia-test
-      DEFAULT_GHCR_USERNAME: copia-automation-bot
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      sync_count: ${{ steps.plan.outputs.sync_count }}
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,31 +43,67 @@ jobs:
         with:
           version: v3.8.1
 
-      - name: Resolve chart image references
-        id: images
+      - name: Log in to Distr
+        run: |
+          set -euo pipefail
+          echo "${DISTR_REGISTRY_PAT}" | docker login "${DISTR_REGISTRY_HOST}" --password-stdin -u -
+        env:
+          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+
+      - name: Build matrix of images missing on Distr
+        id: plan
         run: |
           set -euo pipefail
           CHART_ROOT="${GITHUB_WORKSPACE}/charts/copia"
-          COP=$(helm template mirror "$CHART_ROOT" --show-only templates/copia-deployment.yaml \
-            | sed -n 's/^[[:space:]]*image:[[:space:]]*"\(ghcr.io[^"]*\)".*/\1/p' \
-            | grep -F 'copia-web-app-selfhosted-releases' | head -1)
-          CM=$(helm template mirror "$CHART_ROOT" \
-            --set conversion_manager_service.enabled=true \
-            --show-only templates/conversion-manager-deployment.yaml \
-            | sed -n 's/^[[:space:]]*image:[[:space:]]*"\(ghcr.io[^"]*\)".*/\1/p' \
-            | grep -F 'conversion-manager' | head -1)
-          if [ -z "$COP" ] || [ -z "$CM" ]; then
-            echo "::error::Could not resolve Copia or conversion-manager image from helm templates"
-            echo "copia=${COP:-<empty>} conversion-manager=${CM:-<empty>}"
+          DISTR_PREFIX="${DISTR_REGISTRY_HOST}/${DISTR_NAMESPACE}"
+          helm template mirror "${CHART_ROOT}" --set conversion_manager_service.enabled=true > /tmp/rendered.yaml
+          grep -oE 'ghcr\.io/copia-automation/[A-Za-z0-9._/-]+:[A-Za-z0-9._+-]+' /tmp/rendered.yaml \
+            | sort -u > /tmp/srcs.txt
+          if [ ! -s /tmp/srcs.txt ]; then
+            echo "::error::No ghcr.io/copia-automation images found in rendered chart"
             exit 1
           fi
+          entries=()
+          while IFS= read -r src; do
+            [ -z "${src}" ] && continue
+            remainder="${src#ghcr.io/}"
+            repo_tag="${remainder#*/}"
+            dst="${DISTR_PREFIX}/${repo_tag}"
+            if docker manifest inspect "${dst}" >/dev/null 2>&1; then
+              echo "::notice::Already on Distr (omitted from matrix): ${dst}"
+              continue
+            fi
+            entries+=("$(jq -n --arg src "${src}" --arg dst "${dst}" '{src:$src, dst:$dst}')")
+          done < /tmp/srcs.txt
+          if [ "${#entries[@]}" -eq 0 ]; then
+            matrix_json='[]'
+          else
+            matrix_json=$(printf '%s\n' "${entries[@]}" | jq -s -c .)
+          fi
+          count=$(jq 'length' <<< "${matrix_json}")
+          echo "::notice::Images to sync (matrix size): ${count}"
+          delim="MATRIX_JSON_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
           {
-            echo "copia_src=${COP}"
-            echo "cm_src=${CM}"
+            echo "matrix<<${delim}"
+            echo "${matrix_json}"
+            echo "${delim}"
+            echo "sync_count=${count}"
           } >> "${GITHUB_OUTPUT}"
-          echo "::notice::Copia image: ${COP}"
-          echo "::notice::Conversion manager image: ${CM}"
 
+  sync-to-distr:
+    needs: discover-sync-matrix
+    if: needs.discover-sync-matrix.outputs.sync_count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include: ${{ fromJSON(needs.discover-sync-matrix.outputs.matrix) }}
+    env:
+      DISTR_REGISTRY_HOST: registry.distr.sh
+      DISTR_NAMESPACE: copia-test
+      DEFAULT_GHCR_USERNAME: copia-automation-bot
+    steps:
       - name: Log in to GHCR
         run: |
           set -euo pipefail
@@ -77,22 +120,13 @@ jobs:
         env:
           DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
 
-      - name: Pull, retag, and push to Distr
+      - name: Pull, retag, and push
         env:
-          COP_SRC: ${{ steps.images.outputs.copia_src }}
-          CM_SRC: ${{ steps.images.outputs.cm_src }}
+          SRC: ${{ matrix.src }}
+          DST: ${{ matrix.dst }}
         run: |
           set -euo pipefail
-          DISTR_PREFIX="${DISTR_REGISTRY_HOST}/${DISTR_NAMESPACE}"
-          mirror_one() {
-            local src="$1"
-            local remainder="${src#ghcr.io/}"
-            local repo_tag="${remainder#*/}"
-            local dst="${DISTR_PREFIX}/${repo_tag}"
-            echo "::notice::Mirroring ${src} -> ${dst}"
-            docker pull "${src}"
-            docker tag "${src}" "${dst}"
-            docker push "${dst}"
-          }
-          mirror_one "${COP_SRC}"
-          mirror_one "${CM_SRC}"
+          echo "::notice::Mirroring ${SRC} -> ${DST}"
+          docker pull "${SRC}"
+          docker tag "${SRC}" "${DST}"
+          docker push "${DST}"

--- a/.github/workflows/mirror-containers-to-distr.yaml
+++ b/.github/workflows/mirror-containers-to-distr.yaml
@@ -1,0 +1,98 @@
+name: Mirror Copia images to Distr
+
+# Copies the Copia web app and conversion-manager images referenced by the chart
+# from GHCR to registry.distr.sh (same layout as Distr console examples).
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      GHCR_TOKEN:
+        description: Token with read:packages for pulling ghcr.io/copia-automation/* images
+        required: true
+      GHCR_USERNAME:
+        description: Optional GHCR docker login username (defaults to copia-automation-bot)
+        required: false
+      DISTR_REGISTRY_PAT:
+        description: Distr registry personal access token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    env:
+      DISTR_REGISTRY_HOST: registry.distr.sh
+      DISTR_NAMESPACE: copia-test
+      DEFAULT_GHCR_USERNAME: copia-automation-bot
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.8.1
+
+      - name: Resolve chart image references
+        id: images
+        run: |
+          set -euo pipefail
+          CHART_ROOT="${GITHUB_WORKSPACE}/charts/copia"
+          COP=$(helm template mirror "$CHART_ROOT" --show-only templates/copia-deployment.yaml \
+            | sed -n 's/^[[:space:]]*image:[[:space:]]*"\(ghcr.io[^"]*\)".*/\1/p' \
+            | grep -F 'copia-web-app-selfhosted-releases' | head -1)
+          CM=$(helm template mirror "$CHART_ROOT" \
+            --set conversion_manager_service.enabled=true \
+            --show-only templates/conversion-manager-deployment.yaml \
+            | sed -n 's/^[[:space:]]*image:[[:space:]]*"\(ghcr.io[^"]*\)".*/\1/p' \
+            | grep -F 'conversion-manager' | head -1)
+          if [ -z "$COP" ] || [ -z "$CM" ]; then
+            echo "::error::Could not resolve Copia or conversion-manager image from helm templates"
+            echo "copia=${COP:-<empty>} conversion-manager=${CM:-<empty>}"
+            exit 1
+          fi
+          {
+            echo "copia_src=${COP}"
+            echo "cm_src=${CM}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "::notice::Copia image: ${COP}"
+          echo "::notice::Conversion manager image: ${CM}"
+
+      - name: Log in to GHCR
+        run: |
+          set -euo pipefail
+          USER="${GHCR_USERNAME:-${DEFAULT_GHCR_USERNAME}}"
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${USER}" --password-stdin
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+
+      - name: Log in to Distr
+        run: |
+          set -euo pipefail
+          echo "${DISTR_REGISTRY_PAT}" | docker login "${DISTR_REGISTRY_HOST}" --password-stdin -u -
+        env:
+          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+
+      - name: Pull, retag, and push to Distr
+        env:
+          COP_SRC: ${{ steps.images.outputs.copia_src }}
+          CM_SRC: ${{ steps.images.outputs.cm_src }}
+        run: |
+          set -euo pipefail
+          DISTR_PREFIX="${DISTR_REGISTRY_HOST}/${DISTR_NAMESPACE}"
+          mirror_one() {
+            local src="$1"
+            local remainder="${src#ghcr.io/}"
+            local repo_tag="${remainder#*/}"
+            local dst="${DISTR_PREFIX}/${repo_tag}"
+            echo "::notice::Mirroring ${src} -> ${dst}"
+            docker pull "${src}"
+            docker tag "${src}" "${dst}"
+            docker push "${dst}"
+          }
+          mirror_one "${COP_SRC}"
+          mirror_one "${CM_SRC}"

--- a/.github/workflows/publish-beta-helm-chart.yaml
+++ b/.github/workflows/publish-beta-helm-chart.yaml
@@ -6,20 +6,36 @@ on:
 permissions: write-all
 
 jobs:
+  pr-chart-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      chart_version_ghcr: ${{ steps.v.outputs.chart_version_ghcr }}
+      chart_version_distr: ${{ steps.v.outputs.chart_version_distr }}
+    steps:
+      - id: v
+        run: |
+          set -euo pipefail
+          SHORT=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-8)
+          PR=${{ github.event.pull_request.number }}
+          echo "chart_version_ghcr=0.0.0-beta.pr${PR}" >> "${GITHUB_OUTPUT}"
+          echo "chart_version_distr=0.0.0-beta.pr${PR}.${SHORT}" >> "${GITHUB_OUTPUT}"
+
   # Primary path — unchanged: beta charts on GHCR dev repository.
   publish:
+    needs: pr-chart-versions
     uses: ./.github/workflows/publish-helm-chart.yaml
     secrets: inherit
     with:
-      version: 0.0.0-beta.pr${{ github.event.pull_request.number }}
+      version: ${{ needs.pr-chart-versions.outputs.chart_version_ghcr }}
       registry: ghcr
 
-  # Distr pilot — same chart as GHCR; registry host/path match Distr console (see publish-helm-chart env).
+  # Distr pilot — chart version includes 8-char head SHA so each commit is a distinct chart tag.
   # Requires repo secret DISTR_REGISTRY_PAT. Skipped for fork PRs (secrets are unavailable).
   publish-distr-pilot:
+    needs: pr-chart-versions
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/publish-helm-chart.yaml
     secrets: inherit
     with:
-      version: 0.0.0-beta.pr${{ github.event.pull_request.number }}
+      version: ${{ needs.pr-chart-versions.outputs.chart_version_distr }}
       registry: distr

--- a/.github/workflows/publish-beta-helm-chart.yaml
+++ b/.github/workflows/publish-beta-helm-chart.yaml
@@ -6,7 +6,20 @@ on:
 permissions: write-all
 
 jobs:
+  # Primary path — unchanged: beta charts on GHCR dev repository.
   publish:
     uses: ./.github/workflows/publish-helm-chart.yaml
+    secrets: inherit
     with:
       version: 0.0.0-beta.pr${{ github.event.pull_request.number }}
+      registry: ghcr
+
+  # Distr pilot — same chart as GHCR; registry host/path match Distr console (see publish-helm-chart env).
+  # Requires repo secret DISTR_REGISTRY_PAT. Skipped for fork PRs (secrets are unavailable).
+  publish-distr-pilot:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/publish-helm-chart.yaml
+    secrets: inherit
+    with:
+      version: 0.0.0-beta.pr${{ github.event.pull_request.number }}
+      registry: distr

--- a/.github/workflows/publish-edge-helm-chart.yaml
+++ b/.github/workflows/publish-edge-helm-chart.yaml
@@ -1,0 +1,42 @@
+name: Publish Edge Helm Chart to Distr
+
+# Edge channel (ADR-ENG-19207): every merge to main publishes a prerelease chart
+# to the Distr registry and mirrors the images it references. ADR-ENG-19206 then
+# creates an ApplicationVersion in the `copia-edge` application from this chart.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/copia/**'
+      - '.github/workflows/publish-edge-helm-chart.yaml'
+      - '.github/workflows/publish-helm-chart.yaml'
+      - '.github/workflows/mirror-containers-to-distr.yaml'
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  edge-version:
+    runs-on: ubuntu-latest
+    outputs:
+      chart_version: ${{ steps.v.outputs.chart_version }}
+    steps:
+      - id: v
+        run: |
+          set -euo pipefail
+          SHORT=$(echo "${{ github.sha }}" | cut -c1-8)
+          # Prerelease tag, distinct per commit, sorts below any real release.
+          echo "chart_version=0.0.0-edge.${SHORT}" >> "${GITHUB_OUTPUT}"
+
+  publish-chart:
+    needs: edge-version
+    uses: ./.github/workflows/publish-helm-chart.yaml
+    secrets: inherit
+    with:
+      version: ${{ needs.edge-version.outputs.chart_version }}
+      registry: distr
+
+  mirror-images:
+    uses: ./.github/workflows/mirror-containers-to-distr.yaml
+    secrets: inherit

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -8,10 +8,22 @@ on:
         required: false
         type: string
       production:
-        description: Push to production registry (default dev)
+        description: Push to production registry (default dev; GHCR only)
         required: false
         type: boolean
         default: false
+      registry:
+        description: Target OCI registry (ghcr = GHCR, distr = Distr pilot)
+        required: false
+        type: choice
+        options:
+          - ghcr
+          - distr
+        default: ghcr
+    secrets:
+      DISTR_REGISTRY_PAT:
+        description: Personal access token for Distr artifact registry (registry.distr.sh)
+        required: false
   workflow_dispatch:
     inputs:
       version:
@@ -19,16 +31,28 @@ on:
         required: false
         type: string
       production:
-        description: Push to production registry (default dev)
+        description: Push to production registry (default dev; GHCR only)
         required: false
         type: boolean
         default: false
+      registry:
+        description: Target OCI registry (ghcr = GHCR, distr = Distr pilot)
+        required: false
+        type: choice
+        options:
+          - ghcr
+          - distr
+        default: ghcr
 
 permissions: write-all
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      # Distr console — docker login registry.distr.sh; OCI prefix registry.distr.sh/<slug>/…
+      DISTR_REGISTRY_HOST: registry.distr.sh
+      DISTR_OCI_REPOSITORY: copia-test
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,11 +96,23 @@ jobs:
       - name: Upload chart artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: helm-chart
+          name: helm-chart-${{ inputs.registry }}
           path: copia-*.tgz
 
       - name: Log in to GitHub Container Registry
+        if: inputs.registry == 'ghcr'
         run: echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
 
-      - name: Push Helm chart to registry
+      - name: Log in to Distr registry
+        if: inputs.registry == 'distr'
+        run: echo "$DISTR_REGISTRY_PAT" | helm registry login "$DISTR_REGISTRY_HOST" --username - --password-stdin
+        env:
+          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+
+      - name: Push Helm chart to GHCR
+        if: inputs.registry == 'ghcr'
         run: helm push copia-*.tgz oci://ghcr.io/copia-automation/${{ inputs.production && 'helm-charts' || 'helm-charts-dev' }}
+
+      - name: Push Helm chart to Distr
+        if: inputs.registry == 'distr'
+        run: helm push copia-*.tgz "oci://${DISTR_REGISTRY_HOST}/${DISTR_OCI_REPOSITORY}"

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -13,12 +13,9 @@ on:
         type: boolean
         default: false
       registry:
-        description: Target OCI registry (ghcr = GHCR, distr = Distr pilot)
+        description: 'Target OCI registry: ghcr or distr'
         required: false
-        type: choice
-        options:
-          - ghcr
-          - distr
+        type: string
         default: ghcr
     secrets:
       DISTR_REGISTRY_PAT:
@@ -63,6 +60,18 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.8.1
+
+      - name: Validate registry input
+        env:
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          case "$REGISTRY" in
+            ghcr|distr) ;;
+            *)
+              echo "::error::registry must be ghcr or distr (got: ${REGISTRY})"
+              exit 1
+              ;;
+          esac
 
       - name: Set `version` in Chart.yaml to ${{ inputs.version }}
         if: inputs.version != ''

--- a/.github/workflows/publish-production-helm-chart.yaml
+++ b/.github/workflows/publish-production-helm-chart.yaml
@@ -24,3 +24,19 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.chart-version }}
       production: true
+
+  # Production channel (ADR-ENG-19207): the same release also publishes the chart
+  # to Distr and mirrors the images it references. ADR-ENG-19206 then creates an
+  # ApplicationVersion in the `copia` application from this chart.
+  publish-distr:
+    needs: prepare
+    uses: ./.github/workflows/publish-helm-chart.yaml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.chart-version }}
+      registry: distr
+
+  mirror-images:
+    needs: prepare
+    uses: ./.github/workflows/mirror-containers-to-distr.yaml
+    secrets: inherit

--- a/charts/copia/tests/__snapshot__/distr_backward_compat_test.yaml.snap
+++ b/charts/copia/tests/__snapshot__/distr_backward_compat_test.yaml.snap
@@ -1,0 +1,400 @@
+renders unchanged for a representative existing-customer value set:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: conversion-manager
+        app.kubernetes.io/instance: conversion-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: conversion-manager
+        app.kubernetes.io/version: v0.1.10
+        helm.sh/chart: copia-0.0.0
+        version: v0.1.10
+      name: conversion-manager
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: conversion-manager
+          app.kubernetes.io/name: conversion-manager
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/config: 4c18fea1ad0a3d86ca674f930c0b773731ad1bc3872ebba7290103810051a11c
+            checksum/secret: 56faff83423b499ae78312f416244b95189b16874bc3e800d17b555f75ec7478
+          labels:
+            app: conversion-manager
+            app.kubernetes.io/instance: conversion-manager
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: conversion-manager
+            app.kubernetes.io/version: v0.1.10
+            helm.sh/chart: copia-0.0.0
+            version: v0.1.10
+        spec:
+          containers:
+            - env: null
+              envFrom:
+                - configMapRef:
+                    name: conversion-manager-configmap
+                - secretRef:
+                    name: conversion-manager-secret
+              image: ghcr.io/copia-automation/conversion-manager:v0.1.10
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 2
+                httpGet:
+                  path: /api/v1/ping
+                  port: 8888
+                  scheme: HTTPS
+                periodSeconds: 10
+                timeoutSeconds: 5
+              name: conversion-manager
+              ports:
+                - containerPort: 8888
+                  name: http
+              resources:
+                limits:
+                  cpu: 2
+                  memory: 512Mi
+                requests:
+                  cpu: 0.5
+                  memory: 128Mi
+              startupProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /api/v1/ping
+                  port: 8888
+                  scheme: HTTPS
+                initialDelaySeconds: 20
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+          imagePullSecrets:
+            - name: ghcr-login-secret
+  2: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: copia
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: copia
+        app.kubernetes.io/version: v0.55.0
+        helm.sh/chart: copia-0.0.0
+        version: v0.55.0
+      name: RELEASE-NAME-copia
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: copia
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/config: 2cc0994de9f48e57089a6261bc0397afc2957cbfdbb821d175cf559186518a96
+            checksum/secret: 5043015ce716de592c72f7a0dcbf4019fc4380583f0dd22f46f8e6801446e7dd
+          labels:
+            app: copia
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: copia
+            app.kubernetes.io/version: v0.55.0
+            helm.sh/chart: copia-0.0.0
+            version: v0.55.0
+        spec:
+          containers:
+            - command:
+                - gitea
+              env: null
+              envFrom:
+                - configMapRef:
+                    name: RELEASE-NAME-copia-configmap
+              image: ghcr.io/copia-automation/copia-web-app-selfhosted-releases:v0.55.0
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - sleep 10 && /usr/local/bin/gitea manager shutdown
+              livenessProbe:
+                failureThreshold: 2
+                httpGet:
+                  path: /
+                  port: 4001
+                periodSeconds: 10
+                timeoutSeconds: 2
+              name: copia
+              ports:
+                - containerPort: 22
+                  name: ssh
+                - containerPort: 4001
+                  name: http
+              resources: {}
+              securityContext: {}
+              startupProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /
+                  port: 4001
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                timeoutSeconds: 2
+              volumeMounts:
+                - mountPath: /tmp/gitea
+                  name: temp
+                - mountPath: /data
+                  name: data
+                - mountPath: /data/gitea/conf/app.ini
+                  name: config
+                  subPath: app.ini
+          imagePullSecrets:
+            - name: ghcr-login-secret
+          securityContext:
+            fsGroup: 1000
+          terminationGracePeriodSeconds: 60
+          volumes:
+            - name: config
+              secret:
+                secretName: RELEASE-NAME-copia-ini
+            - emptyDir: {}
+              name: temp
+            - name: data
+              persistentVolumeClaim:
+                claimName: RELEASE-NAME-copia-data
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      labels:
+        app: copia
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: copia
+        app.kubernetes.io/version: v0.55.0
+        helm.sh/chart: copia-0.0.0
+        version: v0.55.0
+      name: RELEASE-NAME-copia-http
+    spec:
+      ports:
+        - name: http
+          port: 3000
+          targetPort: 4001
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: copia
+      type: NodePort
+renders unchanged for default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: conversion-manager
+        app.kubernetes.io/instance: conversion-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: conversion-manager
+        app.kubernetes.io/version: v0.1.10
+        helm.sh/chart: copia-0.0.0
+        version: v0.1.10
+      name: conversion-manager
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: conversion-manager
+          app.kubernetes.io/name: conversion-manager
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/config: 4c18fea1ad0a3d86ca674f930c0b773731ad1bc3872ebba7290103810051a11c
+            checksum/secret: 56faff83423b499ae78312f416244b95189b16874bc3e800d17b555f75ec7478
+          labels:
+            app: conversion-manager
+            app.kubernetes.io/instance: conversion-manager
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: conversion-manager
+            app.kubernetes.io/version: v0.1.10
+            helm.sh/chart: copia-0.0.0
+            version: v0.1.10
+        spec:
+          containers:
+            - env: null
+              envFrom:
+                - configMapRef:
+                    name: conversion-manager-configmap
+                - secretRef:
+                    name: conversion-manager-secret
+              image: ghcr.io/copia-automation/conversion-manager:v0.1.10
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 2
+                httpGet:
+                  path: /api/v1/ping
+                  port: 8888
+                  scheme: HTTPS
+                periodSeconds: 10
+                timeoutSeconds: 5
+              name: conversion-manager
+              ports:
+                - containerPort: 8888
+                  name: http
+              resources:
+                limits:
+                  cpu: 2
+                  memory: 512Mi
+                requests:
+                  cpu: 0.5
+                  memory: 128Mi
+              startupProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /api/v1/ping
+                  port: 8888
+                  scheme: HTTPS
+                initialDelaySeconds: 20
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+          imagePullSecrets:
+            - name: ghcr-login-secret
+  2: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: copia
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: copia
+        app.kubernetes.io/version: v0.55.0
+        helm.sh/chart: copia-0.0.0
+        version: v0.55.0
+      name: RELEASE-NAME-copia
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: copia
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/config: 2cc0994de9f48e57089a6261bc0397afc2957cbfdbb821d175cf559186518a96
+            checksum/secret: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+          labels:
+            app: copia
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: copia
+            app.kubernetes.io/version: v0.55.0
+            helm.sh/chart: copia-0.0.0
+            version: v0.55.0
+        spec:
+          containers:
+            - command:
+                - gitea
+              env: null
+              envFrom:
+                - configMapRef:
+                    name: RELEASE-NAME-copia-configmap
+              image: ghcr.io/copia-automation/copia-web-app-selfhosted-releases:v0.55.0
+              imagePullPolicy: Always
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - sleep 10 && /usr/local/bin/gitea manager shutdown
+              livenessProbe:
+                failureThreshold: 2
+                httpGet:
+                  path: /
+                  port: 4001
+                periodSeconds: 10
+                timeoutSeconds: 2
+              name: copia
+              ports:
+                - containerPort: 22
+                  name: ssh
+                - containerPort: 4001
+                  name: http
+              resources: {}
+              securityContext: {}
+              startupProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /
+                  port: 4001
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                timeoutSeconds: 2
+              volumeMounts:
+                - mountPath: /tmp/gitea
+                  name: temp
+                - mountPath: /data
+                  name: data
+          imagePullSecrets:
+            - name: ghcr-login-secret
+          securityContext:
+            fsGroup: 1000
+          terminationGracePeriodSeconds: 60
+          volumes:
+            - emptyDir: {}
+              name: temp
+            - name: data
+              persistentVolumeClaim:
+                claimName: RELEASE-NAME-copia-data
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: {}
+      labels:
+        app: copia
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: copia
+        app.kubernetes.io/version: v0.55.0
+        helm.sh/chart: copia-0.0.0
+        version: v0.55.0
+      name: RELEASE-NAME-copia-http
+    spec:
+      ports:
+        - name: http
+          port: 3000
+          targetPort: 4001
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: copia
+      type: NodePort

--- a/charts/copia/tests/distr_backward_compat_test.yaml
+++ b/charts/copia/tests/distr_backward_compat_test.yaml
@@ -1,0 +1,36 @@
+# ADR-ENG-19207: Distr support must be backward-compatible. The test is
+# behavioral — an existing value set must render the same manifests before and
+# after a change. These snapshots lock the rendered output of the surface the
+# Distr base-values overlay touches (images, service type, pull secrets,
+# conversion-manager). Regenerate intentionally with `helm unittest -u charts/copia`
+# and review the snapshot diff in the same PR as the change that caused it.
+suite: Distr backward compatibility (golden render)
+templates:
+  - copia-deployment.yaml
+  - copia-service.yaml
+  - conversion-manager-deployment.yaml
+tests:
+  - it: renders unchanged for default values
+    set:
+      conversion_manager_service.enabled: true
+    asserts:
+      - matchSnapshot: {}
+  - it: renders unchanged for a representative existing-customer value set
+    set:
+      service.http.type: NodePort
+      conversion_manager_service.enabled: true
+      conversion_manager_service.service.http.type: NodePort
+      copia.config:
+        APP_NAME: Copia
+        RUN_MODE: prod
+        server:
+          ROOT_URL: https://git.customer.example/
+          DOMAIN: git.customer.example
+          HTTP_PORT: 4001
+        database:
+          HOST: postgres.customer.example:5432
+          NAME: copia
+          USER: copia
+          PASSWD: example
+    asserts:
+      - matchSnapshot: {}

--- a/charts/copia/tests/distr_image_tags_test.yaml
+++ b/charts/copia/tests/distr_image_tags_test.yaml
@@ -1,0 +1,31 @@
+# ADR-ENG-19207: the chart a customer pulls from Distr must carry concrete image
+# tags. This guards against an image reference that ships an unresolved
+# substitution variable (for example a Flux `${...}` placeholder), which would
+# break the agent's plain `helm install`.
+suite: Distr image tags are concrete
+templates:
+  - copia-deployment.yaml
+  - conversion-manager-deployment.yaml
+tests:
+  - it: copia image resolves to a concrete tag with no unresolved variables
+    template: copia-deployment.yaml
+    set:
+      copia.config: {}
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/copia-automation/copia-web-app-selfhosted-releases:.+$'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '\$\{'
+  - it: conversion-manager image resolves to a concrete tag with no unresolved variables
+    template: conversion-manager-deployment.yaml
+    set:
+      conversion_manager_service.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/copia-automation/conversion-manager:.+$'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '\$\{'


### PR DESCRIPTION
This implements ENG-19207 Phase 1: it wires the chart push and image mirror to fire on both delivery channels and adds the two CI guardrails the ADR requires. It is stacked on #158, which provides the reusable `publish-helm-chart` (`registry: distr`) and `mirror-containers-to-distr` workflows; rebase onto `main` once #158 lands.

The edge channel is a new workflow that runs on every merge to `main`: it publishes a prerelease chart (`0.0.0-edge.<sha>`) to the Distr registry and mirrors the images that chart references. The production channel extends the existing release workflow so a published release also pushes the chart to Distr and runs the mirror, alongside the unchanged GHCR push. Both channels reuse the same publish and mirror workflows, differing only in trigger and chart version. Creating the ApplicationVersion in the `copia-edge` and `copia` applications is ADR-ENG-19206's scope and lands in the stacked follow-up.

Two guardrails ship as helm-unittest suites so they run in the existing `script/test` path. `distr_image_tags` asserts both images render a concrete tag with no unresolved substitution variable, which protects the agent's plain `helm install`. `distr_backward_compat` snapshots the rendered surface the Distr base-values overlay touches — images, service type, and conversion-manager — for default values and a representative existing-customer value set, so an accidental change to existing renders fails CI. Regenerate the snapshots intentionally with `helm unittest -u charts/copia` and review the diff in the same PR.

Local `helm unittest charts/copia` passes (14 suites, 39 tests, 6 snapshots).

Draft, no reviewers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)