### PR TITLE
ENG-19206: Create Distr ApplicationVersions and add the values render-check

### DIFF
--- a/.github/workflows/create-distr-version.yaml
+++ b/.github/workflows/create-distr-version.yaml
@@ -1,0 +1,52 @@
+name: Create Distr ApplicationVersion
+
+# ADR-ENG-19206: after the chart is published to Distr, create an ApplicationVersion
+# in the target application from the Distr-hosted chart and the base-values overlay.
+# update-deployments is omitted, so promotion stays manual. The caller selects the
+# application (copia-edge on merge to main, copia on release) and the version name.
+
+on:
+  workflow_call:
+    inputs:
+      application-id:
+        description: Distr application ID to create the version in
+        required: true
+        type: string
+      version-name:
+        description: Human-readable version name
+        required: true
+        type: string
+      chart-version:
+        description: OCI chart version published to Distr
+        required: true
+        type: string
+    secrets:
+      DISTR_TOKEN:
+        description: Distr API token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  create-version:
+    runs-on: ubuntu-latest
+    env:
+      DISTR_REGISTRY_HOST: registry.distr.sh
+      DISTR_OCI_REPOSITORY: copia-test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create ApplicationVersion
+        uses: distr-sh/distr-create-version-action@v1.6.0
+        with:
+          api-token: ${{ secrets.DISTR_TOKEN }}
+          api-base: ${{ vars.DISTR_API_BASE }}
+          application-id: ${{ inputs.application-id }}
+          version-name: ${{ inputs.version-name }}
+          chart-type: oci
+          chart-url: oci://registry.distr.sh/copia-test/copia
+          chart-version: ${{ inputs.chart-version }}
+          base-values-file: charts/copia/distr/values.base.yaml
+          # update-deployments is intentionally unset: promotion is manual.

--- a/.github/workflows/distr-render-check.yaml
+++ b/.github/workflows/distr-render-check.yaml
@@ -1,0 +1,36 @@
+name: Distr values render check
+
+# ADR-ENG-19206: Distr stores base and per-target values as untyped YAML. This
+# renders the chart with the base overlay and a representative per-target overlay
+# so a malformed base value fails here, before it can produce an ApplicationVersion.
+
+on:
+  pull_request:
+    paths:
+      - 'charts/copia/**'
+      - '.github/workflows/distr-render-check.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.8.1
+
+      - name: Render base overlay alone
+        run: helm template copia ./charts/copia -f charts/copia/distr/values.base.yaml > /dev/null
+
+      - name: Render base overlay with a representative per-target overlay
+        run: |
+          helm template copia ./charts/copia \
+            -f charts/copia/distr/values.base.yaml \
+            -f charts/copia/distr/values.example-target.yaml > /dev/null

--- a/.github/workflows/publish-edge-helm-chart.yaml
+++ b/.github/workflows/publish-edge-helm-chart.yaml
@@ -40,3 +40,13 @@ jobs:
   mirror-images:
     uses: ./.github/workflows/mirror-containers-to-distr.yaml
     secrets: inherit
+
+  # ADR-ENG-19206: create the ApplicationVersion in the copia-edge application.
+  create-version:
+    needs: [edge-version, publish-chart, mirror-images]
+    uses: ./.github/workflows/create-distr-version.yaml
+    secrets: inherit
+    with:
+      application-id: ${{ vars.DISTR_APPLICATION_ID_EDGE }}
+      version-name: ${{ needs.edge-version.outputs.chart_version }}
+      chart-version: ${{ needs.edge-version.outputs.chart_version }}

--- a/.github/workflows/publish-production-helm-chart.yaml
+++ b/.github/workflows/publish-production-helm-chart.yaml
@@ -40,3 +40,13 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/mirror-containers-to-distr.yaml
     secrets: inherit
+
+  # ADR-ENG-19206: create the ApplicationVersion in the production copia application.
+  create-version:
+    needs: [prepare, publish-distr, mirror-images]
+    uses: ./.github/workflows/create-distr-version.yaml
+    secrets: inherit
+    with:
+      application-id: ${{ vars.DISTR_APPLICATION_ID }}
+      version-name: ${{ needs.prepare.outputs.chart-version }}
+      chart-version: ${{ needs.prepare.outputs.chart-version }}

--- a/charts/copia/distr/values.base.yaml
+++ b/charts/copia/distr/values.base.yaml
@@ -1,0 +1,71 @@
+# Distr base-values overlay (self-hosted profile).
+#
+# ADR-ENG-19206 attaches this file to the Distr ApplicationVersion via
+# `base-values-file`. It is identical for every customer. Distr merges it UNDER
+# the per-target/customer values, then the agent's `helm install` merges the
+# result over the chart defaults in ../values.yaml.
+#
+# Rules (ADR-ENG-19206 / ENG-19207):
+#   - No `{{ .Secrets.* }}` / `{{ .LicenseKeys.* }}` references here. Distr renders
+#     templating only on the per-target layer; base values are read as plain YAML.
+#   - No image tags here. The tag resolves from the chart (appVersion for the web
+#     app, cmVersion for conversion-manager); pinning a tag would defeat the mirror.
+#   - Customer-supplied keys (database HOST/NAME/USER/PASSWD, server ROOT_URL/DOMAIN/
+#     SSH_DOMAIN, ingress hosts, adminUser, persistence.storageClassName) are set per
+#     target in Distr, not here.
+
+# --- Copia web app ---
+image:
+  # Repository only — tag comes from Chart.appVersion.
+  repository: registry.distr.sh/copia-test/copia-web-app-selfhosted-releases
+
+# The agent injects the Distr registry pull secret, so the chart references none.
+imagePullSecrets: []
+
+# Generate Gitea and conversion-manager bootstrap secrets on a fresh install.
+chartGeneratedSecrets:
+  enabled: true
+
+# Cluster-internal service; ingress/LoadBalancer is a per-customer concern.
+service:
+  http:
+    type: ClusterIP
+
+persistence:
+  enabled: true
+  size: 100Gi
+
+copia:
+  config:
+    APP_NAME: Copia
+    RUN_MODE: prod
+    server:
+      # Vendor-fixed container port; the customer adds ROOT_URL/DOMAIN/SSH_DOMAIN per target.
+      HTTP_PORT: 4001
+    security:
+      # Lock the install so the first run does not expose the setup wizard.
+      INSTALL_LOCK: true
+    service:
+      DISABLE_REGISTRATION: true
+    database:
+      DB_TYPE: postgres
+      SSL_MODE: require
+    storage:
+      # Open (ENG-19206 Phase 2): local PVC for the pilot; may move to object storage.
+      STORAGE_TYPE: local
+    # Per-target / generated (NOT set here):
+    #   server.{ROOT_URL,DOMAIN,SSH_DOMAIN}, database.{HOST,NAME,USER,PASSWD},
+    #   copia.LICENSE_KEY ({{ .LicenseKeys.copia }}), and the secrets that
+    #   chartGeneratedSecrets produces (oauth2.JWT_SECRET, security.INTERNAL_TOKEN, ...).
+
+# --- Conversion-manager (part of the offering; enable in base) ---
+conversion_manager_service:
+  enabled: true
+  deployment:
+    image:
+      # Repository only — tag comes from .Values.cmVersion.
+      repository: registry.distr.sh/copia-test/conversion-manager
+    imagePullSecrets: []
+  service:
+    http:
+      type: ClusterIP

--- a/charts/copia/distr/values.example-target.yaml
+++ b/charts/copia/distr/values.example-target.yaml
@@ -1,0 +1,21 @@
+# Representative per-target (customer) overlay. Used only by the render-check in
+# .github/workflows/distr-render-check.yaml to confirm that the chart renders when
+# the base overlay is combined with a customer's values. It is NOT shipped to any
+# customer. Distr renders {{ .Secrets.* }} / {{ .LicenseKeys.* }} on this layer at
+# deploy time; the placeholders below stand in so `helm template` can validate the merge.
+adminUser:
+  create: true
+  username: admin
+  email: admin@example.com
+  password: rendered-by-distr
+copia:
+  config:
+    server:
+      ROOT_URL: https://copia.example.com/
+      DOMAIN: copia.example.com
+      SSH_DOMAIN: copia.example.com
+    database:
+      HOST: postgres.example.com:5432
+      NAME: copia
+      USER: copia
+      PASSWD: rendered-by-distr

--- a/charts/copia/tests/__snapshot__/distr_backward_compat_test.yaml.snap
+++ b/charts/copia/tests/__snapshot__/distr_backward_compat_test.yaml.snap
@@ -27,7 +27,7 @@ renders unchanged for a representative existing-customer value set:
       template:
         metadata:
           annotations:
-            checksum/config: 4c18fea1ad0a3d86ca674f930c0b773731ad1bc3872ebba7290103810051a11c
+            checksum/config: 4b491f853161af50d444858dd3242b9ead376478f4eb5ce88d3beb76d26410cf
             checksum/secret: 56faff83423b499ae78312f416244b95189b16874bc3e800d17b555f75ec7478
           labels:
             app: conversion-manager
@@ -87,9 +87,9 @@ renders unchanged for a representative existing-customer value set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: copia
-        app.kubernetes.io/version: v0.55.0
+        app.kubernetes.io/version: v0.56.0
         helm.sh/chart: copia-0.0.0
-        version: v0.55.0
+        version: v0.56.0
       name: RELEASE-NAME-copia
     spec:
       replicas: 1
@@ -113,9 +113,9 @@ renders unchanged for a representative existing-customer value set:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: copia
-            app.kubernetes.io/version: v0.55.0
+            app.kubernetes.io/version: v0.56.0
             helm.sh/chart: copia-0.0.0
-            version: v0.55.0
+            version: v0.56.0
         spec:
           containers:
             - command:
@@ -124,7 +124,7 @@ renders unchanged for a representative existing-customer value set:
               envFrom:
                 - configMapRef:
                     name: RELEASE-NAME-copia-configmap
-              image: ghcr.io/copia-automation/copia-web-app-selfhosted-releases:v0.55.0
+              image: ghcr.io/copia-automation/copia-web-app-selfhosted-releases:v0.56.0
               imagePullPolicy: Always
               lifecycle:
                 preStop:
@@ -188,9 +188,9 @@ renders unchanged for a representative existing-customer value set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: copia
-        app.kubernetes.io/version: v0.55.0
+        app.kubernetes.io/version: v0.56.0
         helm.sh/chart: copia-0.0.0
-        version: v0.55.0
+        version: v0.56.0
       name: RELEASE-NAME-copia-http
     spec:
       ports:
@@ -230,7 +230,7 @@ renders unchanged for default values:
       template:
         metadata:
           annotations:
-            checksum/config: 4c18fea1ad0a3d86ca674f930c0b773731ad1bc3872ebba7290103810051a11c
+            checksum/config: 4b491f853161af50d444858dd3242b9ead376478f4eb5ce88d3beb76d26410cf
             checksum/secret: 56faff83423b499ae78312f416244b95189b16874bc3e800d17b555f75ec7478
           labels:
             app: conversion-manager
@@ -290,9 +290,9 @@ renders unchanged for default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: copia
-        app.kubernetes.io/version: v0.55.0
+        app.kubernetes.io/version: v0.56.0
         helm.sh/chart: copia-0.0.0
-        version: v0.55.0
+        version: v0.56.0
       name: RELEASE-NAME-copia
     spec:
       replicas: 1
@@ -316,9 +316,9 @@ renders unchanged for default values:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: copia
-            app.kubernetes.io/version: v0.55.0
+            app.kubernetes.io/version: v0.56.0
             helm.sh/chart: copia-0.0.0
-            version: v0.55.0
+            version: v0.56.0
         spec:
           containers:
             - command:
@@ -327,7 +327,7 @@ renders unchanged for default values:
               envFrom:
                 - configMapRef:
                     name: RELEASE-NAME-copia-configmap
-              image: ghcr.io/copia-automation/copia-web-app-selfhosted-releases:v0.55.0
+              image: ghcr.io/copia-automation/copia-web-app-selfhosted-releases:v0.56.0
               imagePullPolicy: Always
               lifecycle:
                 preStop:
@@ -385,9 +385,9 @@ renders unchanged for default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: copia
-        app.kubernetes.io/version: v0.55.0
+        app.kubernetes.io/version: v0.56.0
         helm.sh/chart: copia-0.0.0
-        version: v0.55.0
+        version: v0.56.0
       name: RELEASE-NAME-copia-http
     spec:
       ports:


### PR DESCRIPTION
This implements ENG-19206 Phase 1: it creates the Distr ApplicationVersion on both channels and adds the values render-check. It is stacked on #164 (which wires the edge and production publish + mirror) and includes the `values.base.yaml` overlay from #163, so the create-version step has a base-values file to attach. Rebase the stack onto `main` once #158, #163, and #164 land.

A reusable `create-distr-version` workflow runs `distr-create-version-action` against the Distr-hosted chart (`oci://registry.distr.sh/copia-test/copia`) and the base-values overlay, with `update-deployments` unset so promotion stays manual. The edge workflow calls it after publish and mirror to create a version in the `copia-edge` application; the release workflow calls it to create a version in the `copia` application. The application IDs and API base come from repository variables.

A `distr-render-check` workflow helm-templates the chart with the base overlay alone and with a representative per-target overlay, so a malformed base value fails in CI before it can produce a version. The example per-target overlay it renders is committed alongside the base overlay and is not shipped to customers.

The backward-compat snapshots are regenerated at the merged `appVersion`. Local `helm unittest charts/copia` passes (15 suites, 51 tests, 6 snapshots), and both render-check commands succeed locally.

Draft, no reviewers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)