### PR TITLE
ENG-19207: Parametrized Distr publish/mirror pipeline (edge, PR, production)

### DIFF
--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -15,9 +15,9 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      chart-version: ${{ steps.v.outputs.chart-version }}
+      chart-version: ${{ steps.version.outputs.chart-version }}
     steps:
-      - id: v
+      - id: version
         run: echo "chart-version=0.0.0-edge.$(echo "${{ github.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -24,7 +24,8 @@ jobs:
   publish:
     needs: version
     uses: ./.github/workflows/distr-publish.yaml
-    secrets: inherit
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -25,7 +25,8 @@ jobs:
     needs: version
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+      DISTR_TOKEN: ${{ secrets.DISTR_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -1,4 +1,4 @@
-name: Publish edge to Distr
+name: Publish "edge" release to Distr
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars.DISTR_REGISTRY_HOST }}
-      oci-namespace: ${{ vars.DISTR_OCI_NAMESPACE }}
-      api-base: ${{ vars.DISTR_API_BASE }}
-      application-id: ${{ vars.DISTR_APP_ID_EDGE }}
+      registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_CLOUD_API_BASE }}
+      application-id: ${{ vars.DISTR_CLOUD_APP_ID_EDGE }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -1,0 +1,32 @@
+name: Publish edge to Distr
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/copia/**'
+      - '.github/workflows/distr-publish*.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      chart-version: ${{ steps.v.outputs.chart-version }}
+    steps:
+      - id: v
+        run: echo "chart-version=0.0.0-edge.$(echo "${{ github.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: version
+    uses: ./.github/workflows/distr-publish.yaml
+    secrets: inherit
+    with:
+      chart-version: ${{ needs.version.outputs.chart-version }}
+      registry-host: ${{ vars.DISTR_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_API_BASE }}
+      application-id: ${{ vars.DISTR_APP_ID_EDGE }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-      DISTR_TOKEN: ${{ secrets.DISTR_TOKEN }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -22,7 +22,8 @@ jobs:
   publish:
     needs: version
     uses: ./.github/workflows/distr-publish.yaml
-    secrets: inherit
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -1,4 +1,4 @@
-name: Publish PR to Distr
+name: Publish PR release to Distr
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars.DISTR_REGISTRY_HOST }}
-      oci-namespace: ${{ vars.DISTR_OCI_NAMESPACE }}
-      api-base: ${{ vars.DISTR_API_BASE }}
-      application-id: ${{ vars.DISTR_APP_ID_PR }}
+      registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_CLOUD_API_BASE }}
+      application-id: ${{ vars.DISTR_CLOUD_APP_ID_PR }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -23,7 +23,8 @@ jobs:
     needs: version
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+      DISTR_TOKEN: ${{ secrets.DISTR_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-      DISTR_TOKEN: ${{ secrets.DISTR_TOKEN }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -21,6 +21,7 @@ jobs:
 
   publish:
     needs: version
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   version:

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -13,9 +13,9 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      chart-version: ${{ steps.v.outputs.chart-version }}
+      chart-version: ${{ steps.version.outputs.chart-version }}
     steps:
-      - id: v
+      - id: version
         run: echo "chart-version=0.0.0-pr${{ github.event.pull_request.number }}.$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -1,0 +1,30 @@
+name: Publish PR to Distr
+
+on:
+  pull_request:
+    paths:
+      - 'charts/copia/**'
+      - '.github/workflows/distr-publish*.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      chart-version: ${{ steps.v.outputs.chart-version }}
+    steps:
+      - id: v
+        run: echo "chart-version=0.0.0-pr${{ github.event.pull_request.number }}.$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: version
+    uses: ./.github/workflows/distr-publish.yaml
+    secrets: inherit
+    with:
+      chart-version: ${{ needs.version.outputs.chart-version }}
+      registry-host: ${{ vars.DISTR_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_API_BASE }}
+      application-id: ${{ vars.DISTR_APP_ID_PR }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -17,12 +17,17 @@ jobs:
       - id: version
         env:
           TAG: ${{ github.event.release.tag_name }}
-        run: echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT"
+        run: |
+          case "$TAG" in
+            copia-*) echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Unexpected release tag: $TAG" >&2; exit 1 ;;
+          esac
 
   publish:
     needs: version
     uses: ./.github/workflows/distr-publish.yaml
-    secrets: inherit
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -27,7 +27,8 @@ jobs:
     needs: version
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+      DISTR_TOKEN: ${{ secrets.DISTR_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-      DISTR_TOKEN: ${{ secrets.DISTR_TOKEN }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -1,12 +1,8 @@
-name: Publish "edge" release to Distr
+name: Publish production release to Distr
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'charts/copia/**'
-      - '.github/workflows/distr-publish*.yaml'
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -19,7 +15,9 @@ jobs:
       chart-version: ${{ steps.version.outputs.chart-version }}
     steps:
       - id: version
-        run: echo "chart-version=0.0.0-edge.$(echo "${{ github.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: version
@@ -30,4 +28,4 @@ jobs:
       registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
       oci-namespace: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
       api-base: ${{ vars.DISTR_CLOUD_API_BASE }}
-      application-id: ${{ vars.DISTR_CLOUD_APP_ID_EDGE }}
+      application-id: ${{ vars.DISTR_CLOUD_APP_ID_PROD }}

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -80,6 +80,9 @@ jobs:
           helm package charts/copia
           helm push copia-*.tgz "oci://${DST}"
 
+      - name: Point base values at the target registry
+        run: sed -i "s#__DISTR_REGISTRY__#${DST}#g" charts/copia/distr/values.base.yaml
+
       - name: Create ApplicationVersion
         uses: distr-sh/distr-create-version-action@f14d2ee8b9750e305b29c6047cc68afbf028e8e7 # v1.6.0
         with:

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -23,17 +23,12 @@ on:
         type: string
         default: ubuntu-latest
     secrets:
-      DISTR_REGISTRY_PAT:
+      OP_SERVICE_ACCOUNT_TOKEN:
         required: true
-      DISTR_TOKEN:
-        required: true
-      GHCR_TOKEN:
-        required: true
-      GHCR_USERNAME:
-        required: false
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   publish:
@@ -47,16 +42,20 @@ jobs:
         with:
           version: v3.8.1
 
+      - uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DISTR_REGISTRY_PAT: op://platform/distr/registry-pat
+          DISTR_TOKEN: op://platform/distr/api-token
+
       - name: Log in to registries
         run: |
           set -euo pipefail
-          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME:-copia-automation-bot}" --password-stdin
-          echo "${DISTR_REGISTRY_PAT}" | docker login "${{ inputs.registry-host }}" -u - --password-stdin
-          echo "${DISTR_REGISTRY_PAT}" | helm registry login "${{ inputs.registry-host }}" -u - --password-stdin
-        env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "$DISTR_REGISTRY_PAT" | docker login "${{ inputs.registry-host }}" -u - --password-stdin
+          echo "$DISTR_REGISTRY_PAT" | helm registry login "${{ inputs.registry-host }}" -u - --password-stdin
 
       - name: Mirror images to Distr
         run: |
@@ -82,7 +81,7 @@ jobs:
       - name: Create ApplicationVersion
         uses: distr-sh/distr-create-version-action@v1.6.0
         with:
-          api-token: ${{ secrets.DISTR_TOKEN }}
+          api-token: ${{ env.DISTR_TOKEN }}
           api-base: ${{ inputs.api-base }}
           application-id: ${{ inputs.application-id }}
           version-name: ${{ inputs.chart-version }}

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -25,7 +25,7 @@ on:
     secrets:
       DISTR_REGISTRY_PAT:
         required: true
-      DISTR_TOKEN:
+      DISTR_API_TOKEN:
         required: true
 
 permissions:
@@ -85,7 +85,7 @@ jobs:
       - name: Create ApplicationVersion
         uses: distr-sh/distr-create-version-action@f14d2ee8b9750e305b29c6047cc68afbf028e8e7 # v1.6.0
         with:
-          api-token: ${{ secrets.DISTR_TOKEN }}
+          api-token: ${{ secrets.DISTR_API_TOKEN }}
           api-base: ${{ inputs.api-base }}
           application-id: ${{ inputs.application-id }}
           version-name: ${{ inputs.chart-version }}

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -1,0 +1,92 @@
+name: Publish to Distr
+
+on:
+  workflow_call:
+    inputs:
+      chart-version:
+        required: true
+        type: string
+      registry-host:
+        required: true
+        type: string
+      oci-namespace:
+        required: true
+        type: string
+      api-base:
+        required: true
+        type: string
+      application-id:
+        required: true
+        type: string
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+    secrets:
+      DISTR_REGISTRY_PAT:
+        required: true
+      DISTR_TOKEN:
+        required: true
+      GHCR_TOKEN:
+        required: true
+      GHCR_USERNAME:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ${{ inputs.runs-on }}
+    env:
+      DST: ${{ inputs.registry-host }}/${{ inputs.oci-namespace }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.8.1
+
+      - name: Log in to registries
+        run: |
+          set -euo pipefail
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME:-copia-automation-bot}" --password-stdin
+          echo "${DISTR_REGISTRY_PAT}" | docker login "${{ inputs.registry-host }}" -u - --password-stdin
+          echo "${DISTR_REGISTRY_PAT}" | helm registry login "${{ inputs.registry-host }}" -u - --password-stdin
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+
+      - name: Mirror images to Distr
+        run: |
+          set -euo pipefail
+          helm template mirror charts/copia --set conversion_manager_service.enabled=true > /tmp/rendered.yaml
+          grep -oE 'ghcr\.io/copia-automation/[A-Za-z0-9._/-]+:[A-Za-z0-9._+-]+' /tmp/rendered.yaml | sort -u > /tmp/srcs.txt
+          test -s /tmp/srcs.txt
+          while IFS= read -r src; do
+            dst="${DST}/${src#ghcr.io/copia-automation/}"
+            if docker manifest inspect "$dst" >/dev/null 2>&1; then continue; fi
+            docker pull "$src"
+            docker tag "$src" "$dst"
+            docker push "$dst"
+          done < /tmp/srcs.txt
+
+      - name: Publish chart to Distr
+        run: |
+          set -euo pipefail
+          sed -i "s/^version:.*/version: ${{ inputs.chart-version }}/" charts/copia/Chart.yaml
+          helm package charts/copia
+          helm push copia-*.tgz "oci://${DST}"
+
+      - name: Create ApplicationVersion
+        uses: distr-sh/distr-create-version-action@v1.6.0
+        with:
+          api-token: ${{ secrets.DISTR_TOKEN }}
+          api-base: ${{ inputs.api-base }}
+          application-id: ${{ inputs.application-id }}
+          version-name: ${{ inputs.chart-version }}
+          chart-type: oci
+          chart-url: oci://${{ inputs.registry-host }}/${{ inputs.oci-namespace }}/copia
+          chart-version: ${{ inputs.chart-version }}
+          base-values-file: charts/copia/distr/values.base.yaml

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -23,7 +23,9 @@ on:
         type: string
         default: ubuntu-latest
     secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
+      DISTR_REGISTRY_PAT:
+        required: true
+      DISTR_TOKEN:
         required: true
 
 permissions:
@@ -42,17 +44,9 @@ jobs:
         with:
           version: v3.8.1
 
-      - uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0
-        with:
-          export-env: true
-        env:
-          # TODO: add OP_SERVICE_ACCOUNT_TOKEN to the helm-charts GitHub secrets,
-          # and create registry-pat and api-token in the 1Password platform vault.
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          DISTR_REGISTRY_PAT: op://platform/distr/registry-pat
-          DISTR_TOKEN: op://platform/distr/api-token
-
       - name: Log in to registries
+        env:
+          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
         run: |
           set -euo pipefail
           echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
@@ -86,7 +80,7 @@ jobs:
       - name: Create ApplicationVersion
         uses: distr-sh/distr-create-version-action@f14d2ee8b9750e305b29c6047cc68afbf028e8e7 # v1.6.0
         with:
-          api-token: ${{ env.DISTR_TOKEN }}
+          api-token: ${{ secrets.DISTR_TOKEN }}
           api-base: ${{ inputs.api-base }}
           application-id: ${{ inputs.application-id }}
           version-name: ${{ inputs.chart-version }}

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -42,16 +42,19 @@ jobs:
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.8.1
+          version: v3.21.2
 
       - name: Log in to registries
         env:
           DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+          REGISTRY_HOST: ${{ inputs.registry-host }}
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          echo "$DISTR_REGISTRY_PAT" | docker login "${{ inputs.registry-host }}" -u - --password-stdin
-          echo "$DISTR_REGISTRY_PAT" | helm registry login "${{ inputs.registry-host }}" -u - --password-stdin
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+          echo "$DISTR_REGISTRY_PAT" | docker login "$REGISTRY_HOST" -u - --password-stdin
+          echo "$DISTR_REGISTRY_PAT" | helm registry login "$REGISTRY_HOST" -u - --password-stdin
 
       - name: Mirror images to Distr
         run: |
@@ -68,9 +71,11 @@ jobs:
           done < /tmp/srcs.txt
 
       - name: Publish chart to Distr
+        env:
+          CHART_VERSION: ${{ inputs.chart-version }}
         run: |
           set -euo pipefail
-          sed -i "s/^version:.*/version: ${{ inputs.chart-version }}/" charts/copia/Chart.yaml
+          sed -i "s/^version:.*/version: ${CHART_VERSION}/" charts/copia/Chart.yaml
           helm package charts/copia
           helm push copia-*.tgz "oci://${DST}"
 

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -46,6 +46,8 @@ jobs:
         with:
           export-env: true
         env:
+          # TODO: add OP_SERVICE_ACCOUNT_TOKEN to the helm-charts GitHub secrets,
+          # and create registry-pat and api-token in the 1Password platform vault.
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DISTR_REGISTRY_PAT: op://platform/distr/registry-pat
           DISTR_TOKEN: op://platform/distr/api-token

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -81,7 +81,7 @@ jobs:
           helm push copia-*.tgz "oci://${DST}"
 
       - name: Create ApplicationVersion
-        uses: distr-sh/distr-create-version-action@v1.6.0
+        uses: distr-sh/distr-create-version-action@f14d2ee8b9750e305b29c6047cc68afbf028e8e7 # v1.6.0
         with:
           api-token: ${{ env.DISTR_TOKEN }}
           api-base: ${{ inputs.api-base }}

--- a/charts/copia/distr/values.base.yaml
+++ b/charts/copia/distr/values.base.yaml
@@ -1,6 +1,6 @@
 # Distr base values overlay. Minimal for now; expanded later with the customer values template.
 image:
-  repository: registry.distr.sh/copia-test/copia-web-app-selfhosted-releases
+  repository: __DISTR_REGISTRY__/copia-web-app-selfhosted-releases
 imagePullSecrets: []
 chartGeneratedSecrets:
   enabled: true
@@ -11,7 +11,7 @@ conversion_manager_service:
   enabled: true
   deployment:
     image:
-      repository: registry.distr.sh/copia-test/conversion-manager
+      repository: __DISTR_REGISTRY__/conversion-manager
     imagePullSecrets: []
   service:
     http:

--- a/charts/copia/distr/values.base.yaml
+++ b/charts/copia/distr/values.base.yaml
@@ -1,0 +1,18 @@
+# Distr base values overlay. Minimal for now; expanded later with the customer values template.
+image:
+  repository: registry.distr.sh/copia-test/copia-web-app-selfhosted-releases
+imagePullSecrets: []
+chartGeneratedSecrets:
+  enabled: true
+service:
+  http:
+    type: ClusterIP
+conversion_manager_service:
+  enabled: true
+  deployment:
+    image:
+      repository: registry.distr.sh/copia-test/conversion-manager
+    imagePullSecrets: []
+  service:
+    http:
+      type: ClusterIP


### PR DESCRIPTION
This adds the end-to-end flow to publish container images and helm releases to Distr. One parametrized workflow does the publishing/mirroring while several top-level workflows provide the event triggers:

- When a commit is merged to main, create a new ApplicationVersion in Distr for the Copia "edge" application. This allows us to pull down and test every commit on main
- When a commit is pushed to a PR, create a new ApplicationVersion in Distr for the Copia "pr" application. This allows us to pull down and test a PR before merging to main
- When a release is published, create a new ApplicationVersion in Distr for the Copia production application. This is the official production application that customers use

## What it does

`distr-publish.yaml` is a reusable workflow that, given a target, performs the flow in order: load the Distr credentials from 1Password, log in to the GHCR source (built-in token) and the Distr registry, mirror the chart's referenced images to Distr (skipping any already present), publish the chart, and create an ApplicationVersion. Its inputs are `registry-host`, `oci-namespace`, `api-base`, `application-id`, `chart-version`, and an optional `runs-on`, and its only secret is `OP_SERVICE_ACCOUNT_TOKEN`. The image set comes from rendering the chart, so the mirror always matches what the chart references (`appVersion`, `cmVersion`).

Three thin callers wire the channels above, differing only in trigger, chart version, and target application:
- `distr-publish-edge.yaml` runs on merge to `main` and publishes `0.0.0-edge.<sha>`.
- `distr-publish-pr.yaml` runs on a pull request and publishes `0.0.0-pr<n>.<sha>`.
- `distr-publish-release.yaml` runs on a published release and publishes the release version.

## Configuration

Each caller resolves its target from `DISTR_CLOUD_*` repository variables (registry host, OCI namespace, API base, and the per-channel application ID), provisioned in platform-tng #2464; the `distr_cloud` prefix leaves room for a self-hosted instance's own set later. The Distr registry PAT and API token load from the 1Password `platform` vault at runtime, so no Distr secret lives in GitHub, and each caller grants `packages: read` for the GHCR pull.

Still required before a run succeeds: `OP_SERVICE_ACCOUNT_TOKEN` reachable from this repo, the `registry-pat` and `api-token` items present in the 1Password `platform` vault, and the real production application ID set in platform-tng #2464 (`DISTR_CLOUD_APP_ID_PROD` is currently a placeholder).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Distr Helm chart publishing for edge (main), PRs, and production (GitHub Releases).
  * Added a Distr base Helm values overlay to standardize image repositories and service defaults, including conversion-manager configuration.
* **Bug Fixes**
  * Added stricter production release tag validation to ensure correct chart version derivation.
  * Avoided redundant container image pushes by skipping images that already exist in the destination registry.
* **Chores**
  * Centralized Distr publishing into a reusable workflow and set publishing workflows to read-only permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->