### PR TITLE
ENG-19894: author Distr base-values vendor profile

### DIFF
--- a/charts/copia/distr/values.base.yaml
+++ b/charts/copia/distr/values.base.yaml
@@ -1,12 +1,26 @@
-# Distr base values overlay. Minimal for now; expanded later with the customer values template.
+# Distr base values overlay: the self-hosted profile applied to every customer.
+# Vendor-fixed keys only. Backing-service ownership (Postgres, object storage,
+# Redis, TLS), the resources and probe profiles, and storage type are decided in
+# Phase 2 (ADR ENG-19206, Appendix A). Secret and license references must never
+# appear here; Distr renders templating only in the per-target layer.
 image:
   repository: __DISTR_REGISTRY__/copia-web-app-selfhosted-releases
 imagePullSecrets: []
 chartGeneratedSecrets:
   enabled: true
+persistence:
+  size: 100Gi
 service:
   http:
     type: ClusterIP
+copia:
+  config:
+    APP_NAME: Copia
+    RUN_MODE: prod
+    security:
+      INSTALL_LOCK: true
+    service:
+      DISABLE_REGISTRATION: true
 conversion_manager_service:
   enabled: true
   deployment:


### PR DESCRIPTION
This change expands `charts/copia/distr/values.base.yaml` from the registry rewrite into the Phase 1 self-hosted profile that Distr applies to every customer. It pins the persistent volume to 100Gi, keeps both HTTP services at `ClusterIP`, and sets the vendor-fixed Gitea settings `APP_NAME`, `RUN_MODE`, `INSTALL_LOCK`, and `DISABLE_REGISTRATION` through `copia.config`, which the chart renders into `app.ini`.

The overlay holds vendor-fixed keys only and carries no secret or license references, because Distr renders templating solely in the per-target layer. The per-target layer supplies the database, host, admin, and secret values. Resources, the probe profile, the storage type, and backing-service ownership remain open and are decided in Phase 2, per ADR ENG-19206 Appendix A.

Verification renders the chart with the base overlay plus a representative per-target overlay through `helm template`. The result is a clean render in which `app.ini` carries the four vendor keys, both services are `ClusterIP`, the persistent volume claim requests 100Gi, and the image references resolve to concrete tags. Rendering the base overlay alone fails by design, because the chart expects the customer layer to supply `copia.config.server`; the publish pipeline never templates the overlay, it attaches the file to the ApplicationVersion.

Task: ENG-19894 (ADR ENG-19206, Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the default self-hosted Copia setup with additional configuration for production use.
  * Enabled persistent storage with a larger default volume.
  * Added settings to lock installation and disable new registrations.
  * Added configuration for the conversion manager service, including its image and service type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->