### PR TITLE
Fix ingress.hosts schema so item constraints are enforced

### DIFF
--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -300,24 +300,30 @@
             },
             "hosts": {
               "type": "array",
-              "additionalProperties": false,
               "description": "Hosts to expose",
-              "required": ["host"],
-              "properties": {
-                "host": {
-                  "type": "string"
-                },
-                "paths": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "description": "Paths",
-                  "properties": {
-                    "path": {
-                      "type": "string",
-                      "description": "Path on host"
-                    },
-                    "pathType": {
-                      "type": "string"
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["host"],
+                "properties": {
+                  "host": {
+                    "type": "string"
+                  },
+                  "paths": {
+                    "type": "array",
+                    "description": "Paths",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "path": {
+                          "type": "string",
+                          "description": "Path on host"
+                        },
+                        "pathType": {
+                          "type": "string"
+                        }
+                      }
                     }
                   }
                 }
@@ -517,24 +523,30 @@
         },
         "hosts": {
           "type": "array",
-          "additionalProperties": false,
           "description": "Hosts to expose",
-          "required": ["host"],
-          "properties": {
-            "host": {
-              "type": "string"
-            },
-            "paths": {
-              "type": "object",
-              "additionalProperties": false,
-              "description": "Paths",
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "description": "Path on host"
-                },
-                "pathType": {
-                  "type": "string"
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["host"],
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "description": "Paths",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "Path on host"
+                    },
+                    "pathType": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -322,6 +322,33 @@
                         },
                         "pathType": {
                           "type": "string"
+                        },
+                        "backend": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "service": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "number": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -545,6 +572,33 @@
                     },
                     "pathType": {
                       "type": "string"
+                    },
+                    "backend": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "service": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "number": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
The `ingress.hosts` schema in `charts/copia/values.schema.json` — and its copy under `conversion_manager_service.ingress.hosts` — declared `"type": "array"` but placed `required` and `properties` as siblings of `type` rather than under `items`. In JSON Schema those keywords only constrain object instances, so on an array with no `items` they are ignored. The result: malformed `ingress.hosts` entries passed validation silently.

This wraps the host object under `items` and models `paths` as an array of `{path, pathType}` objects, matching the chart default `values.yaml` and the template, which ranges over `.paths` in `charts/copia/templates/copia-ingress.yaml`.

The other bare `"type": "array"` properties in the schema (for example `imagePullSecrets`, `tolerations`, `tls`) have no misplaced constraints; an unconstrained array is valid JSON Schema, so they are left as-is.

Verification with `helm template`:
- Chart defaults render (the default `ingress.hosts[].paths` array now validates).
- A host with an array `paths` passes.
- A host with an object `paths` is now correctly rejected: `at '/ingress/hosts/0/paths': got object, want array` — previously it passed silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingress configuration validation to support defining multiple host paths as a list of path entries (each with a path and path type).
  * Updated schema validation to better match the supported ingress path format, reducing setup errors when configuring multiple routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->