### PR TITLE
ENG-20004: clean up PR artifacts in Distr on PR close

### DIFF
--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -1,0 +1,72 @@
+name: Clean up PR release from Distr
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'charts/copia/**'
+      - '.github/workflows/distr-publish*.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    # Fork PRs never receive the secrets to publish, so there is nothing to
+    # clean up for them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      API_BASE: ${{ vars.DISTR_CLOUD_API_BASE }}
+      APP_ID: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
+      REGISTRY_HOST: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
+      OCI_NAMESPACE: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
+      PREFIX: 0.0.0-pr${{ github.event.pull_request.number }}.
+    steps:
+      - name: Archive the PR's ApplicationVersions
+        env:
+          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
+          ids=$(curl -fsSL -H "$auth" "${API_BASE}/applications/${APP_ID}" \
+            | jq -r --arg p "$PREFIX" \
+                '.versions[]? | select(.name | startswith($p)) | select(.archivedAt == null) | .id')
+          if [ -z "$ids" ]; then
+            echo "No ApplicationVersions to archive for ${PREFIX}"
+            exit 0
+          fi
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
+            '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
+          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) for ${PREFIX}"
+          curl -fsSL -X PATCH -H "$auth" -H 'Content-Type: application/json' \
+            -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null
+
+      - name: Delete the PR's chart tags from the Distr registry
+        # The registry may reject manifest deletion; archiving the
+        # ApplicationVersions above is the authoritative cleanup.
+        continue-on-error: true
+        env:
+          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+        run: |
+          set -euo pipefail
+          base="https://${REGISTRY_HOST}/v2/${OCI_NAMESPACE}/copia"
+          accept='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
+          tags=$(curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" "${base}/tags/list" \
+            | jq -r --arg p "$PREFIX" '.tags[]? | select(startswith($p))')
+          if [ -z "$tags" ]; then
+            echo "No chart tags to delete for ${PREFIX}"
+            exit 0
+          fi
+          for tag in $tags; do
+            digest=$(curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" -I -H "Accept: ${accept}" \
+              "${base}/manifests/${tag}" | tr -d '\r' \
+              | awk -F': ' 'tolower($1) == "docker-content-digest" { print $2 }')
+            if [ -z "$digest" ]; then
+              echo "No digest for ${tag}, skipping"
+              continue
+            fi
+            echo "Deleting copia:${tag} (${digest})"
+            curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" -X DELETE "${base}/manifests/${digest}"
+          done

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -25,8 +25,6 @@ jobs:
     env:
       API_BASE: ${{ vars.DISTR_CLOUD_API_BASE }}
       APP_ID: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
-      REGISTRY_HOST: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
-      OCI_NAMESPACE: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Archive matching ApplicationVersions
@@ -48,31 +46,3 @@ jobs:
           echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) matching ${MATCH}"
           curl -fsSL -X PATCH -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null
-
-      - name: Delete matching chart tags from the Distr registry
-        # The registry may reject manifest deletion; archiving the
-        # ApplicationVersions above is the authoritative cleanup.
-        continue-on-error: true
-        env:
-          DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-        run: |
-          set -euo pipefail
-          base="https://${REGISTRY_HOST}/v2/${OCI_NAMESPACE}/copia"
-          accept='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
-          tags=$(curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" "${base}/tags/list" \
-            | jq -r --arg p "$MATCH" '.tags[]? | select(startswith($p))')
-          if [ -z "$tags" ]; then
-            echo "No chart tags to delete for ${MATCH}"
-            exit 0
-          fi
-          for tag in $tags; do
-            digest=$(curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" -I -H "Accept: ${accept}" \
-              "${base}/manifests/${tag}" | tr -d '\r' \
-              | awk -F': ' 'tolower($1) == "docker-content-digest" { print $2 }')
-            if [ -z "$digest" ]; then
-              echo "No digest for ${tag}, skipping"
-              continue
-            fi
-            echo "Deleting copia:${tag} (${digest})"
-            curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" -X DELETE "${base}/manifests/${digest}"
-          done

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -1,9 +1,6 @@
 name: Clean up Distr artifacts
 
 on:
-  # TEMPORARY: one-shot trigger to exercise the workflow; remove after.
-  push:
-    branches: [ENG-20004-cleanup-pr-distr-artifacts]
   pull_request:
     types: [closed]
     paths:
@@ -23,14 +20,14 @@ jobs:
   cleanup:
     # Fork PRs never receive the secrets to publish, so there is nothing to
     # clean up for them; manual dispatch is always allowed.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       API_BASE: ${{ vars.DISTR_CLOUD_API_BASE }}
       APP_ID: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
       REGISTRY_HOST: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
       OCI_NAMESPACE: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
-      MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event_name == 'push' && '0.0.0-pr168.' || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
+      MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Archive matching ApplicationVersions
         env:

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: distr-cleanup-${{ github.event_name == 'workflow_dispatch' && inputs.version || format('pr-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     # Fork PRs never receive the secrets to publish, so there is nothing to
@@ -33,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
-          ids=$(curl -fsSL -H "$auth" "${API_BASE}/applications/${APP_ID}" \
+          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${APP_ID}" \
             | jq -r --arg p "$MATCH" \
                 '.versions[]? | select(.name | startswith($p)) | select(.archivedAt == null) | .id')
           if [ -z "$ids" ]; then
@@ -44,5 +48,5 @@ jobs:
           body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
             '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
           echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) matching ${MATCH}"
-          curl -fsSL -X PATCH -H "$auth" -H 'Content-Type: application/json' \
+          curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -1,4 +1,4 @@
-name: Clean up PR release from Distr
+name: Clean up Distr artifacts
 
 on:
   pull_request:
@@ -6,6 +6,12 @@ on:
     paths:
       - 'charts/copia/**'
       - '.github/workflows/distr-publish*.yaml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: ApplicationVersion name or prefix to clean up (for example 0.0.0-pr123. or 0.0.0-pr123.abc1234)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,37 +19,37 @@ permissions:
 jobs:
   cleanup:
     # Fork PRs never receive the secrets to publish, so there is nothing to
-    # clean up for them.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # clean up for them; manual dispatch is always allowed.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       API_BASE: ${{ vars.DISTR_CLOUD_API_BASE }}
       APP_ID: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
       REGISTRY_HOST: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
       OCI_NAMESPACE: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
-      PREFIX: 0.0.0-pr${{ github.event.pull_request.number }}.
+      MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
-      - name: Archive the PR's ApplicationVersions
+      - name: Archive matching ApplicationVersions
         env:
           DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
         run: |
           set -euo pipefail
           auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
           ids=$(curl -fsSL -H "$auth" "${API_BASE}/applications/${APP_ID}" \
-            | jq -r --arg p "$PREFIX" \
+            | jq -r --arg p "$MATCH" \
                 '.versions[]? | select(.name | startswith($p)) | select(.archivedAt == null) | .id')
           if [ -z "$ids" ]; then
-            echo "No ApplicationVersions to archive for ${PREFIX}"
+            echo "No ApplicationVersions to archive for ${MATCH}"
             exit 0
           fi
           now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
             '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
-          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) for ${PREFIX}"
+          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) matching ${MATCH}"
           curl -fsSL -X PATCH -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null
 
-      - name: Delete the PR's chart tags from the Distr registry
+      - name: Delete matching chart tags from the Distr registry
         # The registry may reject manifest deletion; archiving the
         # ApplicationVersions above is the authoritative cleanup.
         continue-on-error: true
@@ -54,9 +60,9 @@ jobs:
           base="https://${REGISTRY_HOST}/v2/${OCI_NAMESPACE}/copia"
           accept='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
           tags=$(curl -fsSL -u "-:${DISTR_REGISTRY_PAT}" "${base}/tags/list" \
-            | jq -r --arg p "$PREFIX" '.tags[]? | select(startswith($p))')
+            | jq -r --arg p "$MATCH" '.tags[]? | select(startswith($p))')
           if [ -z "$tags" ]; then
-            echo "No chart tags to delete for ${PREFIX}"
+            echo "No chart tags to delete for ${MATCH}"
             exit 0
           fi
           for tag in $tags; do

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -1,6 +1,9 @@
 name: Clean up Distr artifacts
 
 on:
+  # TEMPORARY: one-shot trigger to exercise the workflow; remove after.
+  push:
+    branches: [ENG-20004-cleanup-pr-distr-artifacts]
   pull_request:
     types: [closed]
     paths:
@@ -20,14 +23,14 @@ jobs:
   cleanup:
     # Fork PRs never receive the secrets to publish, so there is nothing to
     # clean up for them; manual dispatch is always allowed.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       API_BASE: ${{ vars.DISTR_CLOUD_API_BASE }}
       APP_ID: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
       REGISTRY_HOST: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
       OCI_NAMESPACE: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
-      MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
+      MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event_name == 'push' && '0.0.0-pr168.' || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Archive matching ApplicationVersions
         env:


### PR DESCRIPTION
When a PR touching `charts/copia/**` or the Distr publish workflows is closed, there are published ApplicationVersions for that PR in the copia-pr Application in Distr. This workflow archives them so they do not accumulate in the Distr UI.

## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow to clean up Distr release artifacts by archiving matching versions when a pull request is closed (scoped to the relevant chart area) or when triggered manually.
  * The cleanup runs for non-fork pull requests; manual runs can target a specific version prefix or use the pull request number.
  * Matching unarchived versions are archived; if none are found, the workflow completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
