### PR TITLE
Publish all channels to Distr staging [ENG-20066]

### DIFF
--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -27,7 +27,7 @@ jobs:
     # clean up for them; manual dispatch is always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - prefix: DISTR_CLOUD

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -30,12 +30,12 @@ jobs:
       matrix:
         include:
           - prefix: DISTR_CLOUD
-            runs-on: ubuntu-latest
+            runs-on: '["ubuntu-latest"]'
             api-token: DISTR_API_TOKEN
           - prefix: DISTR_STAGING
-            runs-on: staging # todo: use correct runner label
+            runs-on: '["staging", "self-hosted"]'
             api-token: DISTR_STAGING_API_TOKEN
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ fromJSON(matrix.runs-on) }}
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
       APP_NAME: copia-pr

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: distr-cleanup-${{ github.event_name == 'workflow_dispatch' && inputs.version || format('pr-{0}', github.event.pull_request.number) }}
@@ -30,15 +31,27 @@ jobs:
       matrix:
         include:
           - prefix: DISTR_CLOUD
-            runs-on: '["ubuntu-latest"]'
+            tailscale: false
           - prefix: DISTR_STAGING
-            runs-on: '["staging", "self-hosted"]'
-    runs-on: ${{ fromJSON(matrix.runs-on) }}
+            tailscale: true
+    runs-on: ubuntu-latest
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
       APP_NAME: copia-pr
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
+      - name: Connect to staging tailnet
+        if: ${{ matrix.tailscale }}
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci
+
+      - name: Route egress through staging exit node
+        if: ${{ matrix.tailscale }}
+        run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
+
       - name: Archive matching ApplicationVersions
         env:
           DISTR_API_TOKEN: ${{ matrix.prefix == 'DISTR_CLOUD' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      APP_NAME: ${{ vars[format('{0}_APP_NAME_PR', matrix.prefix)] }}
+      APP_NAME: copia-pr
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Archive matching ApplicationVersions

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -31,10 +31,8 @@ jobs:
         include:
           - prefix: DISTR_CLOUD
             runs-on: '["ubuntu-latest"]'
-            api-token: DISTR_API_TOKEN
           - prefix: DISTR_STAGING
             runs-on: '["staging", "self-hosted"]'
-            api-token: DISTR_STAGING_API_TOKEN
     runs-on: ${{ fromJSON(matrix.runs-on) }}
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
@@ -43,7 +41,7 @@ jobs:
     steps:
       - name: Archive matching ApplicationVersions
         env:
-          DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
+          DISTR_API_TOKEN: ${{ matrix.prefix == 'DISTR_CLOUD' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
         run: |
           set -euo pipefail
           auth="Authorization: AccessToken ${DISTR_API_TOKEN}"

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -33,7 +33,7 @@ jobs:
             runs-on: ubuntu-latest
             api-token: DISTR_API_TOKEN
           - prefix: DISTR_STAGING
-            runs-on: staging
+            runs-on: staging # todo: use correct runner label
             api-token: DISTR_STAGING_API_TOKEN
     runs-on: ${{ matrix.runs-on }}
     env:

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -25,15 +25,25 @@ jobs:
     # Fork PRs never receive the secrets to publish, so there is nothing to
     # clean up for them; manual dispatch is always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - prefix: DISTR_CLOUD
+            runs-on: ubuntu-latest
+            api-token: DISTR_API_TOKEN
+          - prefix: DISTR_STAGING
+            runs-on: staging
+            api-token: DISTR_STAGING_API_TOKEN
+    runs-on: ${{ matrix.runs-on }}
     env:
-      API_BASE: ${{ vars.DISTR_CLOUD_API_BASE }}
-      APP_ID: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
+      API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
+      APP_ID: ${{ vars[format('{0}_APP_ID_PR', matrix.prefix)] }}
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Archive matching ApplicationVersions
         env:
-          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+          DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
         run: |
           set -euo pipefail
           auth="Authorization: AccessToken ${DISTR_API_TOKEN}"

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      APP_ID: ${{ vars[format('{0}_APP_ID_PR', matrix.prefix)] }}
+      APP_NAME: ${{ vars[format('{0}_APP_NAME_PR', matrix.prefix)] }}
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Archive matching ApplicationVersions
@@ -47,7 +47,13 @@ jobs:
         run: |
           set -euo pipefail
           auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
-          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${APP_ID}" \
+          app_id=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications" \
+            | jq -r --arg name "$APP_NAME" '.[] | select(.name == $name) | .id' | head -n1)
+          if [ -z "$app_id" ] || [ "$app_id" = "null" ]; then
+            echo "::error::Distr application not found: ${APP_NAME}" >&2
+            exit 1
+          fi
+          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${app_id}" \
             | jq -r --arg p "$MATCH" \
                 '.versions[]? | select(.name | startswith($p)) | select(.archivedAt == null) | .id')
           if [ -z "$ids" ]; then
@@ -59,4 +65,4 @@ jobs:
             '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
           echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) matching ${MATCH}"
           curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
-            -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null
+            -d "$body" "${API_BASE}/applications/${app_id}" >/dev/null

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -29,12 +29,12 @@ jobs:
         include:
           - target: cloud
             prefix: DISTR_CLOUD
-            runs-on: ubuntu-latest
+            runs-on: '["ubuntu-latest"]'
             registry-pat: DISTR_REGISTRY_PAT
             api-token: DISTR_API_TOKEN
           - target: staging
             prefix: DISTR_STAGING
-            runs-on: staging # todo: use correct runner label
+            runs-on: '["staging", "self-hosted"]'
             registry-pat: DISTR_STAGING_REGISTRY_PAT
             api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -46,5 +46,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-id: ${{ vars[format('{0}_APP_ID_EDGE', matrix.prefix)] }}
+      application-name: ${{ vars[format('{0}_APP_NAME_EDGE', matrix.prefix)] }}
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -29,10 +29,10 @@ jobs:
         include:
           - target: cloud
             prefix: DISTR_CLOUD
-            runs-on: '["ubuntu-latest"]'
+            tailscale: false
           - target: staging
             prefix: DISTR_STAGING
-            runs-on: '["staging", "self-hosted"]'
+            tailscale: true
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
@@ -43,4 +43,4 @@ jobs:
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
       application-name: copia-edge
-      runs-on: ${{ matrix.runs-on }}
+      tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -25,7 +25,7 @@ jobs:
   publish:
     needs: version
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - target: cloud

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -30,17 +30,13 @@ jobs:
           - target: cloud
             prefix: DISTR_CLOUD
             runs-on: '["ubuntu-latest"]'
-            registry-pat: DISTR_REGISTRY_PAT
-            api-token: DISTR_API_TOKEN
           - target: staging
             prefix: DISTR_STAGING
             runs-on: '["staging", "self-hosted"]'
-            registry-pat: DISTR_STAGING_REGISTRY_PAT
-            api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ secrets[matrix.registry-pat] }}
-      DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
+      DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ matrix.target == 'cloud' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -23,13 +23,28 @@ jobs:
 
   publish:
     needs: version
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: cloud
+            prefix: DISTR_CLOUD
+            runs-on: ubuntu-latest
+            registry-pat: DISTR_REGISTRY_PAT
+            api-token: DISTR_API_TOKEN
+          - target: staging
+            prefix: DISTR_STAGING
+            runs-on: staging # todo: use correct runner label
+            registry-pat: DISTR_STAGING_REGISTRY_PAT
+            api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets[matrix.registry-pat] }}
+      DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
-      oci-namespace: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
-      api-base: ${{ vars.DISTR_CLOUD_API_BASE }}
-      application-id: ${{ vars.DISTR_CLOUD_APP_ID_EDGE }}
+      registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
+      oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
+      api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
+      application-id: ${{ vars[format('{0}_APP_ID_EDGE', matrix.prefix)] }}
+      runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   version:

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -46,5 +46,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: ${{ vars[format('{0}_APP_NAME_EDGE', matrix.prefix)] }}
+      application-name: copia-edge
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -28,10 +28,10 @@ jobs:
         include:
           - target: cloud
             prefix: DISTR_CLOUD
-            runs-on: '["ubuntu-latest"]'
+            tailscale: false
           - target: staging
             prefix: DISTR_STAGING
-            runs-on: '["staging", "self-hosted"]'
+            tailscale: true
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
@@ -42,4 +42,4 @@ jobs:
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
       application-name: copia-pr
-      runs-on: ${{ matrix.runs-on }}
+      tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   version:

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -24,7 +24,7 @@ jobs:
     needs: version
     if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - target: cloud

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -29,17 +29,13 @@ jobs:
           - target: cloud
             prefix: DISTR_CLOUD
             runs-on: '["ubuntu-latest"]'
-            registry-pat: DISTR_REGISTRY_PAT
-            api-token: DISTR_API_TOKEN
           - target: staging
             prefix: DISTR_STAGING
             runs-on: '["staging", "self-hosted"]'
-            registry-pat: DISTR_STAGING_REGISTRY_PAT
-            api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ secrets[matrix.registry-pat] }}
-      DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
+      DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ matrix.target == 'cloud' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -45,5 +45,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: ${{ vars[format('{0}_APP_NAME_PR', matrix.prefix)] }}
+      application-name: copia-pr
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -45,5 +45,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-id: ${{ vars[format('{0}_APP_ID_PR', matrix.prefix)] }}
+      application-name: ${{ vars[format('{0}_APP_NAME_PR', matrix.prefix)] }}
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -22,13 +22,28 @@ jobs:
   publish:
     needs: version
     if: github.event.pull_request.head.repo.full_name == github.repository
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: cloud
+            prefix: DISTR_CLOUD
+            runs-on: ubuntu-latest
+            registry-pat: DISTR_REGISTRY_PAT
+            api-token: DISTR_API_TOKEN
+          - target: staging
+            prefix: DISTR_STAGING
+            runs-on: staging # todo: use correct runner label
+            registry-pat: DISTR_STAGING_REGISTRY_PAT
+            api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets[matrix.registry-pat] }}
+      DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
-      oci-namespace: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
-      api-base: ${{ vars.DISTR_CLOUD_API_BASE }}
-      application-id: ${{ vars.DISTR_CLOUD_APP_ID_PR }}
+      registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
+      oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
+      api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
+      application-id: ${{ vars[format('{0}_APP_ID_PR', matrix.prefix)] }}
+      runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -28,12 +28,12 @@ jobs:
         include:
           - target: cloud
             prefix: DISTR_CLOUD
-            runs-on: ubuntu-latest
+            runs-on: '["ubuntu-latest"]'
             registry-pat: DISTR_REGISTRY_PAT
             api-token: DISTR_API_TOKEN
           - target: staging
             prefix: DISTR_STAGING
-            runs-on: staging # todo: use correct runner label
+            runs-on: '["staging", "self-hosted"]'
             registry-pat: DISTR_STAGING_REGISTRY_PAT
             api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -48,5 +48,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: ${{ vars[format('{0}_APP_NAME_PROD', matrix.prefix)] }}
+      application-name: copia
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -25,13 +25,28 @@ jobs:
 
   publish:
     needs: version
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: cloud
+            prefix: DISTR_CLOUD
+            runs-on: ubuntu-latest
+            registry-pat: DISTR_REGISTRY_PAT
+            api-token: DISTR_API_TOKEN
+          - target: staging
+            prefix: DISTR_STAGING
+            runs-on: staging # todo: use correct runner label
+            registry-pat: DISTR_STAGING_REGISTRY_PAT
+            api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
-      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets[matrix.registry-pat] }}
+      DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars.DISTR_CLOUD_REGISTRY_HOST }}
-      oci-namespace: ${{ vars.DISTR_CLOUD_OCI_NAMESPACE }}
-      api-base: ${{ vars.DISTR_CLOUD_API_BASE }}
-      application-id: ${{ vars.DISTR_CLOUD_APP_ID_PROD }}
+      registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
+      oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
+      api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
+      application-id: ${{ vars[format('{0}_APP_ID_PROD', matrix.prefix)] }}
+      runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   version:

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -48,5 +48,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-id: ${{ vars[format('{0}_APP_ID_PROD', matrix.prefix)] }}
+      application-name: ${{ vars[format('{0}_APP_NAME_PROD', matrix.prefix)] }}
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -27,7 +27,7 @@ jobs:
   publish:
     needs: version
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - target: cloud

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -32,17 +32,13 @@ jobs:
           - target: cloud
             prefix: DISTR_CLOUD
             runs-on: '["ubuntu-latest"]'
-            registry-pat: DISTR_REGISTRY_PAT
-            api-token: DISTR_API_TOKEN
           - target: staging
             prefix: DISTR_STAGING
             runs-on: '["staging", "self-hosted"]'
-            registry-pat: DISTR_STAGING_REGISTRY_PAT
-            api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ secrets[matrix.registry-pat] }}
-      DISTR_API_TOKEN: ${{ secrets[matrix.api-token] }}
+      DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ matrix.target == 'cloud' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -31,12 +31,12 @@ jobs:
         include:
           - target: cloud
             prefix: DISTR_CLOUD
-            runs-on: ubuntu-latest
+            runs-on: '["ubuntu-latest"]'
             registry-pat: DISTR_REGISTRY_PAT
             api-token: DISTR_API_TOKEN
           - target: staging
             prefix: DISTR_STAGING
-            runs-on: staging # todo: use correct runner label
+            runs-on: '["staging", "self-hosted"]'
             registry-pat: DISTR_STAGING_REGISTRY_PAT
             api-token: DISTR_STAGING_API_TOKEN
     uses: ./.github/workflows/distr-publish.yaml

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -31,10 +31,10 @@ jobs:
         include:
           - target: cloud
             prefix: DISTR_CLOUD
-            runs-on: '["ubuntu-latest"]'
+            tailscale: false
           - target: staging
             prefix: DISTR_STAGING
-            runs-on: '["staging", "self-hosted"]'
+            tailscale: true
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
@@ -45,4 +45,4 @@ jobs:
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
       application-name: copia
-      runs-on: ${{ matrix.runs-on }}
+      tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -15,7 +15,7 @@ on:
       api-base:
         required: true
         type: string
-      application-id:
+      application-name:
         required: true
         type: string
       runs-on:
@@ -82,12 +82,30 @@ jobs:
       - name: Point base values at the target registry
         run: sed -i "s#__DISTR_REGISTRY__#${DST}#g" charts/copia/distr/values.base.yaml
 
+      - name: Resolve Distr application ID
+        id: app
+        env:
+          API_BASE: ${{ inputs.api-base }}
+          APP_NAME: ${{ inputs.application-name }}
+          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          APP_ID=$(curl -fsSL --max-time 30 \
+            -H "Authorization: AccessToken ${DISTR_API_TOKEN}" \
+            "${API_BASE}/applications" \
+            | jq -r --arg name "${APP_NAME}" '.[] | select(.name == $name) | .id' | head -n1)
+          if [ -z "${APP_ID}" ] || [ "${APP_ID}" = "null" ]; then
+            echo "::error::Distr application not found: ${APP_NAME}" >&2
+            exit 1
+          fi
+          echo "application-id=${APP_ID}" >> "${GITHUB_OUTPUT}"
+
       - name: Create ApplicationVersion
         uses: distr-sh/distr-create-version-action@f14d2ee8b9750e305b29c6047cc68afbf028e8e7 # v1.6.0
         with:
           api-token: ${{ secrets.DISTR_API_TOKEN }}
           api-base: ${{ inputs.api-base }}
-          application-id: ${{ inputs.application-id }}
+          application-id: ${{ steps.app.outputs.application-id }}
           version-name: ${{ inputs.chart-version }}
           chart-type: oci
           chart-url: oci://${{ inputs.registry-host }}/${{ inputs.oci-namespace }}/copia

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -19,9 +19,13 @@ on:
         required: true
         type: string
       runs-on:
+        # JSON-encoded array of runner labels, e.g. '["ubuntu-latest"]' or
+        # '["staging", "self-hosted"]'. workflow_call inputs cannot be arrays,
+        # so this string is decoded with fromJSON at the job below.
+        description: JSON-encoded array of runner labels
         required: false
         type: string
-        default: ubuntu-latest
+        default: '["ubuntu-latest"]'
     secrets:
       DISTR_REGISTRY_PAT:
         required: true
@@ -34,7 +38,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       DST: ${{ inputs.registry-host }}/${{ inputs.oci-namespace }}
     steps:

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -18,14 +18,13 @@ on:
       application-name:
         required: true
         type: string
-      runs-on:
-        # JSON-encoded array of runner labels, e.g. '["ubuntu-latest"]' or
-        # '["staging", "self-hosted"]'. workflow_call inputs cannot be arrays,
-        # so this string is decoded with fromJSON at the job below.
-        description: JSON-encoded array of runner labels
+      tailscale:
+        # When true, join the tailnet and route egress through the staging
+        # exit node so the runner can reach Distr staging inside its VPC.
+        description: Connect to the staging tailnet via a Tailscale exit node
         required: false
-        type: string
-        default: '["ubuntu-latest"]'
+        type: boolean
+        default: false
     secrets:
       DISTR_REGISTRY_PAT:
         required: true
@@ -35,14 +34,27 @@ on:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   publish:
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ubuntu-latest
     env:
       DST: ${{ inputs.registry-host }}/${{ inputs.oci-namespace }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Connect to staging tailnet
+        if: ${{ inputs.tailscale }}
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci
+
+      - name: Route egress through staging exit node
+        if: ${{ inputs.tailscale }}
+        run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:


### PR DESCRIPTION
Publishes every ApplicationVersion to the self-hosted Distr staging instance in addition to Distr cloud, across all three channels (production, PR, edge). Each publish workflow (and the PR cleanup workflow) now fans out over a cloud + staging target matrix; the staging leg reads `DISTR_STAGING_*` variables and secrets and runs on the self-hosted `staging` runner. `fail-fast: true` keeps the two legs coupled.

The `DISTR_STAGING_*` variables and secrets are provisioned in platform-tng (separate PR). The `staging` runner label is a placeholder pending confirmation of the correct runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Distr publish and cleanup automation to run for both cloud and staging targets in parallel using a shared, matrix-driven setup.
  * Edge, PR, and release publish flows now pass environment-specific settings and credentials and use an application name input.
* **Bug Fixes**
  * Improved reliability by resolving the correct Distr application ID at runtime via the Distr API and failing if no match is found.
* **Chores**
  * Standardized runner selection to use a JSON-encoded array and updated the reusable workflow interface accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->