### PR TITLE
chore:ENG-17655 Pin actions/checkout to SHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Description
Pins the unpinned `actions/checkout@v4` reference in `.github/workflows/tests.yaml` to commit SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` ([ENG-17655](https://app.clickup.com/t/45000662/ENG-17655) org Actions SHA-pin audit remediation).

## Checklist
<!-- Please place an "x" between brackets to mark each relevant box -->

<!-- This Pull Request ... -->
- [x] Links to Clickup
- [x] Follows PR title convention (`<label>:ENG-XXXX <description>`)
- [ ] Introduces new tests on the code paths changed
- [ ] Has been manually verified
- [ ] Generates no new console or log warnings/errors (manual check)
- [ ] Documentation added/updated as applicable

## Testing Description
N/A for runtime — change is GitHub Actions `uses:` pin-only. Verified the pin equals the current `actions/checkout` `v4` tag tip (`34e114876b0b11c390a56381ad16ebd13914f8d5`). No workflow execute/verify run was performed.

### Before

N/A

### After

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated testing workflow to use a fixed version of the repository checkout action, improving build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->