### PR TITLE
ci: separate Distr artifacts per release channel [ENG-20123]

### DIFF
--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -26,6 +26,9 @@ jobs:
     # Fork PRs never receive the secrets to publish, so there is nothing to
     # clean up for them; manual dispatch is always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    # Cleans both Distr instances during rollout. Future (ENG-20123): PR
+    # versions/tags will live only in staging; keep just the staging matrix leg
+    # then.
     strategy:
       fail-fast: false
       matrix:
@@ -37,7 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      APP_NAME: copia-pr
+      # PR ApplicationVersions live under the single copia app; PR charts live
+      # in their own copia-pr artifact repo.
+      APP_NAME: copia
+      ARTIFACT_NAME: copia-pr
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Connect to staging tailnet
@@ -77,3 +83,34 @@ jobs:
           echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) matching ${MATCH}"
           curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${API_BASE}/applications/${app_id}" >/dev/null
+
+      - name: Delete PR artifact tags
+        env:
+          DISTR_API_TOKEN: ${{ matrix.prefix == 'DISTR_CLOUD' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
+          art_id=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/artifacts" \
+            | jq -r --arg name "$ARTIFACT_NAME" '.[]? | select(.name == $name) | .id' | head -n1)
+          if [ -z "$art_id" ] || [ "$art_id" = "null" ]; then
+            echo "No ${ARTIFACT_NAME} artifact found; nothing to delete"
+            exit 0
+          fi
+          tags=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/artifacts/${art_id}" \
+            | jq -r --arg p "$MATCH" '.versions[]?.tags[]?.name | select(startswith($p))' | sort -u)
+          if [ -z "$tags" ]; then
+            echo "No ${ARTIFACT_NAME} tags to delete for ${MATCH}"
+            exit 0
+          fi
+          echo "Deleting $(printf '%s\n' "$tags" | grep -c .) ${ARTIFACT_NAME} tag(s) matching ${MATCH}"
+          # A tag delete can be refused (at least one tag must remain per
+          # artifact); log and continue rather than fail the cleanup.
+          printf '%s\n' "$tags" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            if curl -fsSL --connect-timeout 10 --max-time 30 -X DELETE -H "$auth" \
+                "${API_BASE}/artifacts/${art_id}/tags/${tag}" >/dev/null; then
+              echo "  deleted ${tag}"
+            else
+              echo "  ::warning::could not delete ${tag}"
+            fi
+          done

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -20,10 +20,30 @@ jobs:
       chart-version: ${{ steps.version.outputs.chart-version }}
     steps:
       - id: version
-        run: echo "chart-version=0.0.0-edge.$(echo "${{ github.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Base the edge version on the next minor of the latest release, so it
+          # sorts above the last release but below the next final. The numeric
+          # epoch orders edge builds chronologically per semver; the sha8 traces
+          # the commit. Switch to a patch bump by changing the next= line.
+          latest=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+          base=${latest#copia-}
+          if printf '%s' "$base" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            major=${base%%.*}; rest=${base#*.}; minor=${rest%%.*}
+            next="${major}.$((minor + 1)).0"
+          else
+            next="0.0.0"
+          fi
+          echo "chart-version=${next}-edge.$(date -u +%s).$(printf '%s' "$SHA" | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: version
+    # Publishes to both Distr instances during rollout. Future (ENG-20123):
+    # production and edge versions will live only in the prod instance; drop
+    # the staging matrix leg here once that instance exists.
     strategy:
       fail-fast: false
       matrix:
@@ -43,5 +63,6 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: copia-edge
+      chart-name: copia-edge
       tailscale: ${{ matrix.tailscale }}
+      archive-previous: true

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -23,6 +23,9 @@ jobs:
   publish:
     needs: version
     if: github.event.pull_request.head.repo.full_name == github.repository
+    # Publishes to both Distr instances during rollout. Future (ENG-20123): PR
+    # versions will live only in staging; drop the cloud matrix leg here once
+    # the prod/staging split lands.
     strategy:
       fail-fast: false
       matrix:
@@ -42,5 +45,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: copia-pr
+      chart-name: copia-pr
       tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -26,6 +26,9 @@ jobs:
 
   publish:
     needs: version
+    # Publishes to both Distr instances during rollout. Future (ENG-20123):
+    # production and edge versions will live only in the prod instance; drop
+    # the staging matrix leg here once that instance exists.
     strategy:
       fail-fast: false
       matrix:
@@ -45,5 +48,5 @@ jobs:
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: copia
+      chart-name: copia
       tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -15,13 +15,23 @@ on:
       api-base:
         required: true
         type: string
-      application-name:
+      chart-name:
+        # The per-channel artifact repo the chart is pushed to and the
+        # ApplicationVersion points at, for example copia, copia-edge, copia-pr.
+        description: Artifact repo name for this release channel
         required: true
         type: string
       tailscale:
         # When true, join the tailnet and route egress through the staging
         # exit node so the runner can reach Distr staging inside its VPC.
         description: Connect to the staging tailnet via a Tailscale exit node
+        required: false
+        type: boolean
+        default: false
+      archive-previous:
+        # Edge only: after publishing, archive superseded edge
+        # ApplicationVersions so only the newest stays live.
+        description: Archive superseded edge ApplicationVersions after publishing
         required: false
         type: boolean
         default: false
@@ -89,11 +99,15 @@ jobs:
       - name: Publish chart to Distr
         env:
           CHART_VERSION: ${{ inputs.chart-version }}
+          CHART_NAME: ${{ inputs.chart-name }}
         run: |
           set -euo pipefail
+          # Rename the chart so it lands in its own per-channel artifact repo;
+          # helm push derives the OCI repo from Chart.yaml name.
+          sed -i "s/^name:.*/name: ${CHART_NAME}/" charts/copia/Chart.yaml
           sed -i "s/^version:.*/version: ${CHART_VERSION}/" charts/copia/Chart.yaml
           helm package charts/copia
-          helm push copia-*.tgz "oci://${DST}"
+          helm push "${CHART_NAME}"-*.tgz "oci://${DST}"
 
       - name: Point base values at the target registry
         run: sed -i "s#__DISTR_REGISTRY__#${DST}#g" charts/copia/distr/values.base.yaml
@@ -102,7 +116,7 @@ jobs:
         id: app
         env:
           API_BASE: ${{ inputs.api-base }}
-          APP_NAME: ${{ inputs.application-name }}
+          APP_NAME: copia
           DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
         run: |
           set -euo pipefail
@@ -124,7 +138,33 @@ jobs:
           application-id: ${{ steps.app.outputs.application-id }}
           version-name: ${{ inputs.chart-version }}
           chart-type: oci
-          chart-url: oci://${{ inputs.registry-host }}/${{ inputs.oci-namespace }}/copia
+          chart-url: oci://${{ inputs.registry-host }}/${{ inputs.oci-namespace }}/${{ inputs.chart-name }}
           chart-version: ${{ inputs.chart-version }}
           base-values-file: ${{ github.workspace }}/charts/copia/distr/values.base.yaml
           template-file: ${{ github.workspace }}/charts/copia/distr/values.customer.example.yaml
+
+      - name: Archive superseded edge versions
+        if: ${{ inputs.archive-previous }}
+        env:
+          API_BASE: ${{ inputs.api-base }}
+          APP_ID: ${{ steps.app.outputs.application-id }}
+          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
+          # Match edge versions by the "-edge." infix; the base version varies.
+          # Keep the newest by createdAt, archive the rest.
+          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${APP_ID}" \
+            | jq -r '
+                [.versions[]? | select(.name | test("-edge\\.")) | select(.archivedAt == null)]
+                | sort_by(.createdAt) | reverse | .[1:] | .[].id')
+          if [ -z "$ids" ]; then
+            echo "No superseded edge versions to archive"
+            exit 0
+          fi
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
+            '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
+          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) superseded edge version(s)"
+          curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
+            -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null


### PR DESCRIPTION
Our Distr publish pipeline modeled each release channel as its own application (`copia`, `copia-edge`, `copia-pr`), but every channel pushed its chart to the same `oci://$DST/copia` artifact and hard-coded the ApplicationVersion `chart-url` there. So edge and PR builds landed in the customer-facing `copia` artifact, cluttering what a production customer browses and pulls, and the three applications never actually separated anything beyond the version name.

This change collapses the three applications into a single `copia` application and gives each channel its own artifact repo: stable to `copia`, edge to `copia-edge`, PR to `copia-pr`. Each channel still creates an ApplicationVersion, so edge and PR stay deployable through Distr for validation, but its `chart-url` now points at the per-channel repo. Which versions a customer sees is left to per-version entitlements; edge and PR versions are simply never entitled, so they stay invisible without needing a separate application.

Edge versions move to `<next-minor>-edge.<epoch>.<sha8>` (for example `1.4.0-edge.1752494400.abc1234` when `1.3.5` is the latest release): the numeric epoch orders builds chronologically per semver, the next-minor base sorts edge above the last release but below the next final, and the sha8 keeps traceability. After each edge publish the workflow archives superseded edge versions so only the newest stays live. PR cleanup now archives the PR ApplicationVersion under `copia` and deletes the PR tags from the `copia-pr` artifact; note artifact tags are hard-deleted, unlike ApplicationVersions which are archived.

I kept the existing two-target matrix so every channel still publishes to both Distr cloud and staging during rollout; a comment in each caller notes the future split where production and edge live only in the prod instance and PR lives only in staging.

Before the first cloud edge/PR publish, audit existing `copia` entitlements so they list explicit stable version IDs rather than an empty (all-versions) list, otherwise edge/PR versions would become visible. The old `copia-edge` and `copia-pr` applications can be retired in both instances once no new versions land there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Edge releases now receive automatically generated version identifiers for improved traceability.
  - Publishing can archive superseded edge releases while retaining the latest version.

- **Bug Fixes**
  - Updated release workflows to publish and deploy the correct chart artifacts.
  - Improved cleanup of pull-request releases by removing matching artifact tags and archived application versions.
  - Cleanup now continues safely when no matching artifacts or tags are found.

- **Chores**
  - Standardized chart publishing across pull-request, edge, and production release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->