### PR TITLE
chore:ENG-20238 Enable Action digest pinning in Renovate [CU-86ajj681f]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
## Description
Updates the existing Renovate config in `helm-charts` for [ENG-20238](https://app.clickup.com/t/86ajj681f):

- **Added:** `helpers:pinGitHubActionDigests` so Renovate can SHA-digest-pin GitHub Actions
- **Preserved:** all other existing Renovate settings (extends, packageRules, schedules, secrets/hostRules, etc.)
- **Not changed:** workflows, application code, or other files

Config path: `.github/renovate.json` (base branch: `main`)

## Checklist
<!-- Please place an "x" between brackets to mark each relevant box -->

<!-- This Pull Request ... -->
- [x] Links to Clickup
- [x] Follows PR title convention (`<label>:ENG-XXXX <description>`)
- [ ] Introduces new tests on the code paths changed
- [ ] Has been manually verified
- [ ] Generates no new console or log warnings/errors (manual check)
- [ ] Documentation added/updated as applicable

## Testing Description
N/A — config-only change (append Renovate preset). Verified helper was missing on default branch and no other settings were removed.

### Before

N/A

### After

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update configuration to help keep GitHub Actions references pinned to specific versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->