### PR TITLE
ci: single Distr app and artifact per instance, staging only [ENG-20123]

### DIFF
--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -26,18 +26,22 @@ jobs:
     # Fork PRs never receive the secrets to publish, so there is nothing to
     # clean up for them; manual dispatch is always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    # TODO(ENG-20123): Distr staging stands in as the production instance until
+    # the real production instance is ready; then add its matrix leg. Distr
+    # cloud is intentionally no longer targeted.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - prefix: DISTR_CLOUD
-            tailscale: false
           - prefix: DISTR_STAGING
             tailscale: true
     runs-on: ubuntu-latest
     env:
       API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      APP_NAME: copia-pr
+      # One application and one artifact per instance hold every channel; PR
+      # versions and chart tags live in the shared copia app and copia artifact.
+      APP_NAME: copia
+      ARTIFACT_NAME: copia
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Connect to staging tailnet
@@ -54,7 +58,7 @@ jobs:
 
       - name: Archive matching ApplicationVersions
         env:
-          DISTR_API_TOKEN: ${{ matrix.prefix == 'DISTR_CLOUD' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
+          DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
         run: |
           set -euo pipefail
           auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
@@ -77,3 +81,36 @@ jobs:
           echo "Archiving $(printf '%s\n' "$ids" | grep -c .) version(s) matching ${MATCH}"
           curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${API_BASE}/applications/${app_id}" >/dev/null
+
+      - name: Delete PR artifact tags
+        env:
+          DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
+          art_id=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/artifacts" \
+            | jq -r --arg name "$ARTIFACT_NAME" '.[]? | select(.name == $name) | .id' | head -n1)
+          if [ -z "$art_id" ] || [ "$art_id" = "null" ]; then
+            echo "No ${ARTIFACT_NAME} artifact found; nothing to delete"
+            exit 0
+          fi
+          # MATCH is the PR-specific prefix (0.0.0-pr<n>.), so only PR tags are
+          # selected; stable and edge tags in the shared artifact are untouched.
+          tags=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/artifacts/${art_id}" \
+            | jq -r --arg p "$MATCH" '.versions[]?.tags[]?.name | select(startswith($p))' | sort -u)
+          if [ -z "$tags" ]; then
+            echo "No ${ARTIFACT_NAME} tags to delete for ${MATCH}"
+            exit 0
+          fi
+          echo "Deleting $(printf '%s\n' "$tags" | grep -c .) ${ARTIFACT_NAME} tag(s) matching ${MATCH}"
+          # A tag delete can be refused (at least one tag must remain per
+          # artifact); log and continue rather than fail the cleanup.
+          printf '%s\n' "$tags" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            if curl -fsSL --connect-timeout 10 --max-time 30 -X DELETE -H "$auth" \
+                "${API_BASE}/artifacts/${art_id}/tags/${tag}" >/dev/null; then
+              echo "  deleted ${tag}"
+            else
+              echo "  ::warning::could not delete ${tag}"
+            fi
+          done

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -26,18 +26,13 @@ jobs:
     # Fork PRs never receive the secrets to publish, so there is nothing to
     # clean up for them; manual dispatch is always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-    # TODO(ENG-20123): Distr staging stands in as the production instance until
-    # the real production instance is ready; then add its matrix leg. Distr
-    # cloud is intentionally no longer targeted.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - prefix: DISTR_STAGING
-            tailscale: true
+    # TODO(ENG-20123): cleanup targets Distr staging, which stands in as the
+    # production instance until the real one is ready. To add the production
+    # instance later, reintroduce a matrix over the two instances. Distr cloud is
+    # intentionally no longer targeted.
     runs-on: ubuntu-latest
     env:
-      API_BASE: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
+      API_BASE: ${{ vars.DISTR_STAGING_API_BASE }}
       # One application and one artifact per instance hold every channel; PR
       # versions and chart tags live in the shared copia app and copia artifact.
       APP_NAME: copia
@@ -45,7 +40,6 @@ jobs:
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
       - name: Connect to staging tailnet
-        if: ${{ matrix.tailscale }}
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
           oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
@@ -53,7 +47,6 @@ jobs:
           tags: tag:ci
 
       - name: Route egress through staging exit node
-        if: ${{ matrix.tailscale }}
         run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
 
       - name: Archive matching ApplicationVersions

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -20,28 +20,45 @@ jobs:
       chart-version: ${{ steps.version.outputs.chart-version }}
     steps:
       - id: version
-        run: echo "chart-version=0.0.0-edge.$(echo "${{ github.sha }}" | cut -c1-8)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Base the edge version on the next minor of the latest release, so it
+          # sorts above the last release but below the next final. The numeric
+          # epoch orders edge builds chronologically per semver; the sha8 traces
+          # the commit. Switch to a patch bump by changing the next= line.
+          latest=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+          base=${latest#copia-}
+          if printf '%s' "$base" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            major=${base%%.*}; rest=${base#*.}; minor=${rest%%.*}
+            next="${major}.$((minor + 1)).0"
+          else
+            next="0.0.0"
+          fi
+          echo "chart-version=${next}-edge.$(date -u +%s).$(printf '%s' "$SHA" | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: version
+    # TODO(ENG-20123): Distr staging stands in as the production instance until
+    # the real production instance is ready; then add its matrix leg. Distr
+    # cloud is intentionally no longer targeted.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: cloud
-            prefix: DISTR_CLOUD
-            tailscale: false
           - target: staging
             prefix: DISTR_STAGING
             tailscale: true
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
-      DISTR_API_TOKEN: ${{ matrix.target == 'cloud' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: copia-edge
       tailscale: ${{ matrix.tailscale }}
+      archive-previous: true

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -13,6 +13,12 @@ permissions:
   packages: read
   id-token: write
 
+# Serialize edge runs so overlapping publishes do not race on the archive
+# job's snapshot-then-PATCH of the version list.
+concurrency:
+  group: distr-publish-edge-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -60,8 +66,11 @@ jobs:
   # so the app UI stays clean. Runs on its own runner, so it re-joins the
   # staging tailnet and resolves the copia application itself.
   archive:
+    name: Archive superseded edge versions
     needs: publish
     runs-on: ubuntu-latest
+    # id-token: write lets the Tailscale action mint an OIDC token for its OAuth
+    # flow; no other scopes are needed since this job does not check out code.
     permissions:
       id-token: write
     steps:
@@ -76,6 +85,10 @@ jobs:
         run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
 
       - name: Archive superseded edge versions
+        # Best-effort: publishing already succeeded, and the next edge run
+        # re-archives anything left behind, so a transient API error here must
+        # not fail the workflow.
+        continue-on-error: true
         env:
           API_BASE: ${{ vars.DISTR_STAGING_API_BASE }}
           DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -55,4 +55,52 @@ jobs:
       oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
       api-base: ${{ vars.DISTR_STAGING_API_BASE }}
       tailscale: true
-      archive-previous: true
+
+  # Edge only: after the publish job succeeds, keep a single live edge version
+  # so the app UI stays clean. Runs on its own runner, so it re-joins the
+  # staging tailnet and resolves the copia application itself.
+  archive:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Connect to staging tailnet
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TS_AUDIENCE }}
+          tags: tag:ci
+
+      - name: Route egress through staging exit node
+        run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
+
+      - name: Archive superseded edge versions
+        env:
+          API_BASE: ${{ vars.DISTR_STAGING_API_BASE }}
+          DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
+          app_id=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications" \
+            | jq -r --arg name copia '.[] | select(.name == $name) | .id' | head -n1)
+          if [ -z "$app_id" ] || [ "$app_id" = "null" ]; then
+            echo "::error::Distr application not found: copia" >&2
+            exit 1
+          fi
+          # Match edge versions by the "-edge." infix; the base version varies.
+          # Keep the newest by createdAt, archive the rest.
+          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${app_id}" \
+            | jq -r '
+                [.versions[]? | select(.name | test("-edge\\.")) | select(.archivedAt == null)]
+                | sort_by(.createdAt) | reverse | .[1:] | .[].id')
+          if [ -z "$ids" ]; then
+            echo "No superseded edge versions to archive"
+            exit 0
+          fi
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
+            '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
+          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) superseded edge version(s)"
+          curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
+            -d "$body" "${API_BASE}/applications/${app_id}" >/dev/null

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -41,24 +41,18 @@ jobs:
 
   publish:
     needs: version
-    # TODO(ENG-20123): Distr staging stands in as the production instance until
-    # the real production instance is ready; then add its matrix leg. Distr
-    # cloud is intentionally no longer targeted.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: staging
-            prefix: DISTR_STAGING
-            tailscale: true
+    # TODO(ENG-20123): all publishing targets Distr staging, which stands in as
+    # the production instance until the real one is ready. To add the production
+    # instance later, reintroduce a matrix over the two instances. Distr cloud is
+    # intentionally no longer targeted.
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
       DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
-      oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
-      api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      tailscale: ${{ matrix.tailscale }}
+      registry-host: ${{ vars.DISTR_STAGING_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_STAGING_API_BASE }}
+      tailscale: true
       archive-previous: true

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -23,24 +23,23 @@ jobs:
   publish:
     needs: version
     if: github.event.pull_request.head.repo.full_name == github.repository
+    # TODO(ENG-20123): Distr staging stands in as the production instance until
+    # the real production instance is ready; then add its matrix leg. Distr
+    # cloud is intentionally no longer targeted.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: cloud
-            prefix: DISTR_CLOUD
-            tailscale: false
           - target: staging
             prefix: DISTR_STAGING
             tailscale: true
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
-      DISTR_API_TOKEN: ${{ matrix.target == 'cloud' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: copia-pr
       tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -23,23 +23,17 @@ jobs:
   publish:
     needs: version
     if: github.event.pull_request.head.repo.full_name == github.repository
-    # TODO(ENG-20123): Distr staging stands in as the production instance until
-    # the real production instance is ready; then add its matrix leg. Distr
-    # cloud is intentionally no longer targeted.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: staging
-            prefix: DISTR_STAGING
-            tailscale: true
+    # TODO(ENG-20123): all publishing targets Distr staging, which stands in as
+    # the production instance until the real one is ready. To add the production
+    # instance later, reintroduce a matrix over the two instances. Distr cloud is
+    # intentionally no longer targeted.
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
       DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
-      oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
-      api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      tailscale: ${{ matrix.tailscale }}
+      registry-host: ${{ vars.DISTR_STAGING_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_STAGING_API_BASE }}
+      tailscale: true

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -26,24 +26,23 @@ jobs:
 
   publish:
     needs: version
+    # TODO(ENG-20123): Distr staging stands in as the production instance until
+    # the real production instance is ready; then add its matrix leg. Distr
+    # cloud is intentionally no longer targeted.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: cloud
-            prefix: DISTR_CLOUD
-            tailscale: false
           - target: staging
             prefix: DISTR_STAGING
             tailscale: true
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
-      DISTR_REGISTRY_PAT: ${{ matrix.target == 'cloud' && secrets.DISTR_REGISTRY_PAT || secrets.DISTR_STAGING_REGISTRY_PAT }}
-      DISTR_API_TOKEN: ${{ matrix.target == 'cloud' && secrets.DISTR_API_TOKEN || secrets.DISTR_STAGING_API_TOKEN }}
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
       registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
       oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
       api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      application-name: copia
       tailscale: ${{ matrix.tailscale }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -26,23 +26,17 @@ jobs:
 
   publish:
     needs: version
-    # TODO(ENG-20123): Distr staging stands in as the production instance until
-    # the real production instance is ready; then add its matrix leg. Distr
-    # cloud is intentionally no longer targeted.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: staging
-            prefix: DISTR_STAGING
-            tailscale: true
+    # TODO(ENG-20123): all publishing targets Distr staging, which stands in as
+    # the production instance until the real one is ready. To add the production
+    # instance later, reintroduce a matrix over the two instances. Distr cloud is
+    # intentionally no longer targeted.
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
       DISTR_API_TOKEN: ${{ secrets.DISTR_STAGING_API_TOKEN }}
     with:
       chart-version: ${{ needs.version.outputs.chart-version }}
-      registry-host: ${{ vars[format('{0}_REGISTRY_HOST', matrix.prefix)] }}
-      oci-namespace: ${{ vars[format('{0}_OCI_NAMESPACE', matrix.prefix)] }}
-      api-base: ${{ vars[format('{0}_API_BASE', matrix.prefix)] }}
-      tailscale: ${{ matrix.tailscale }}
+      registry-host: ${{ vars.DISTR_STAGING_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_STAGING_API_BASE }}
+      tailscale: true

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -15,13 +15,17 @@ on:
       api-base:
         required: true
         type: string
-      application-name:
-        required: true
-        type: string
       tailscale:
         # When true, join the tailnet and route egress through the staging
         # exit node so the runner can reach Distr staging inside its VPC.
         description: Connect to the staging tailnet via a Tailscale exit node
+        required: false
+        type: boolean
+        default: false
+      archive-previous:
+        # Edge only: after publishing, archive superseded edge
+        # ApplicationVersions so only the newest stays live.
+        description: Archive superseded edge ApplicationVersions after publishing
         required: false
         type: boolean
         default: false
@@ -102,7 +106,9 @@ jobs:
         id: app
         env:
           API_BASE: ${{ inputs.api-base }}
-          APP_NAME: ${{ inputs.application-name }}
+          # One application per instance holds every channel (stable, edge, PR),
+          # differentiated by version name.
+          APP_NAME: copia
           DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
         run: |
           set -euo pipefail
@@ -128,3 +134,29 @@ jobs:
           chart-version: ${{ inputs.chart-version }}
           base-values-file: ${{ github.workspace }}/charts/copia/distr/values.base.yaml
           template-file: ${{ github.workspace }}/charts/copia/distr/values.customer.example.yaml
+
+      - name: Archive superseded edge versions
+        if: ${{ inputs.archive-previous }}
+        env:
+          API_BASE: ${{ inputs.api-base }}
+          APP_ID: ${{ steps.app.outputs.application-id }}
+          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
+          # Match edge versions by the "-edge." infix; the base version varies.
+          # Keep the newest by createdAt, archive the rest.
+          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${APP_ID}" \
+            | jq -r '
+                [.versions[]? | select(.name | test("-edge\\.")) | select(.archivedAt == null)]
+                | sort_by(.createdAt) | reverse | .[1:] | .[].id')
+          if [ -z "$ids" ]; then
+            echo "No superseded edge versions to archive"
+            exit 0
+          fi
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
+            '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
+          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) superseded edge version(s)"
+          curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
+            -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -22,13 +22,6 @@ on:
         required: false
         type: boolean
         default: false
-      archive-previous:
-        # Edge only: after publishing, archive superseded edge
-        # ApplicationVersions so only the newest stays live.
-        description: Archive superseded edge ApplicationVersions after publishing
-        required: false
-        type: boolean
-        default: false
     secrets:
       DISTR_REGISTRY_PAT:
         required: true
@@ -134,29 +127,3 @@ jobs:
           chart-version: ${{ inputs.chart-version }}
           base-values-file: ${{ github.workspace }}/charts/copia/distr/values.base.yaml
           template-file: ${{ github.workspace }}/charts/copia/distr/values.customer.example.yaml
-
-      - name: Archive superseded edge versions
-        if: ${{ inputs.archive-previous }}
-        env:
-          API_BASE: ${{ inputs.api-base }}
-          APP_ID: ${{ steps.app.outputs.application-id }}
-          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          auth="Authorization: AccessToken ${DISTR_API_TOKEN}"
-          # Match edge versions by the "-edge." infix; the base version varies.
-          # Keep the newest by createdAt, archive the rest.
-          ids=$(curl -fsSL --connect-timeout 10 --max-time 30 -H "$auth" "${API_BASE}/applications/${APP_ID}" \
-            | jq -r '
-                [.versions[]? | select(.name | test("-edge\\.")) | select(.archivedAt == null)]
-                | sort_by(.createdAt) | reverse | .[1:] | .[].id')
-          if [ -z "$ids" ]; then
-            echo "No superseded edge versions to archive"
-            exit 0
-          fi
-          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          body=$(printf '%s\n' "$ids" | jq -R -s --arg t "$now" \
-            '{versions: (split("\n") | map(select(length > 0)) | map({id: ., archivedAt: $t}))}')
-          echo "Archiving $(printf '%s\n' "$ids" | grep -c .) superseded edge version(s)"
-          curl -fsSL --connect-timeout 10 --max-time 30 -X PATCH -H "$auth" -H 'Content-Type: application/json' \
-            -d "$body" "${API_BASE}/applications/${APP_ID}" >/dev/null


### PR DESCRIPTION
- Publishes all versions/artifacts to staging Distr. Nothing is sent to Cloud distr anymore
- All release channels (production, pr, edge) not use the same distr Application and Artifacts
- In a future PR when production Distr is ready, stable production releases will be published to prod Distr while pr and edge releases will stay in staging Distr so they don't clutter prod 