### PR TITLE
Publish stable Helm releases to self-hosted prod Distr (ENG-19202)

### DIFF
--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -54,16 +54,14 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT"
 
-  publish:
+  # Stable releases (and manual backfills) ship to BOTH instances: staging and
+  # self-hosted production. Edge/PR stay staging-only.
+  publish-staging:
     needs: version
     permissions:
       contents: read
       packages: read
       id-token: write
-    # TODO(ENG-20123): all publishing targets Distr staging, which stands in as
-    # the production instance until the real one is ready. To add the production
-    # instance later, reintroduce a matrix over the two instances. Distr cloud is
-    # intentionally no longer targeted.
     uses: ./.github/workflows/distr-publish.yaml
     secrets:
       DISTR_REGISTRY_PAT: ${{ secrets.DISTR_STAGING_REGISTRY_PAT }}
@@ -75,3 +73,20 @@ jobs:
       api-base: ${{ vars.DISTR_STAGING_API_BASE }}
       ref: ${{ needs.version.outputs.tag }}
       exit-node: ${{ vars.DISTR_STAGING_EXIT_NODE }}
+
+  publish-production:
+    needs: version
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    uses: ./.github/workflows/distr-publish.yaml
+    secrets:
+      DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
+      DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+    with:
+      chart-version: ${{ needs.version.outputs.chart-version }}
+      registry-host: ${{ vars.DISTR_PROD_REGISTRY_HOST }}
+      oci-namespace: ${{ vars.DISTR_PROD_OCI_NAMESPACE }}
+      api-base: ${{ vars.DISTR_PROD_API_BASE }}
+      ref: ${{ needs.version.outputs.tag }}


### PR DESCRIPTION
## Summary
- Stable (`release`) Distr publishes now go to **staging and production** self-hosted Distr.
- Production uses `DISTR_PROD_*` vars + `DISTR_REGISTRY_PAT` / `DISTR_API_TOKEN` (no Tailscale; public `pkg.copia.io`).
- Edge/PR workflows unchanged (staging only).

## Depends on
- platform-tng Terraform that sets `DISTR_PROD_*` → `pkg.copia.io` / `flex.copia.io` and wires prod secrets from `distr-prod-*` 1Password items.
- Prod Distr apps `copia` + tokens minted and stored in 1Password before the first prod publish.

## Test plan
- [ ] Confirm GitHub Actions vars `DISTR_PROD_*` exist on this repo after platform-tng apply
- [ ] Confirm secrets `DISTR_REGISTRY_PAT` / `DISTR_API_TOKEN` are prod self-hosted tokens
- [ ] Dry-run or next `copia-*` release: staging job + production job both succeed
- [ ] `helm pull oci://pkg.copia.io/copia/copia --version <ver>` works through Cloudflare


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing pipeline to use separate staging and production publishing steps.
  * Stable (and manually backfilled) releases now publish to both staging and production, while edge/PR releases remain staging-only.
  * Production publishing is handled independently from staging publishing for more granular control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->