### PR TITLE
ci: backfill existing releases to Distr via manual dispatch

### DIFF
--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -39,14 +39,14 @@ jobs:
       ARTIFACT_NAME: copia
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
-      - name: Connect to staging tailnet
+      - name: Connect to tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
           oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
 
-      - name: Route egress through staging exit node
+      - name: Route egress through exit node
         run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
 
       - name: Archive matching ApplicationVersions

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -60,11 +60,11 @@ jobs:
       registry-host: ${{ vars.DISTR_STAGING_REGISTRY_HOST }}
       oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
       api-base: ${{ vars.DISTR_STAGING_API_BASE }}
-      tailscale: true
+      exit-node: ${{ vars.DISTR_STAGING_EXIT_NODE }}
 
   # Edge only: after the publish job succeeds, keep a single live edge version
   # so the app UI stays clean. Runs on its own runner, so it re-joins the
-  # staging tailnet and resolves the copia application itself.
+  # tailnet and resolves the copia application itself.
   archive:
     name: Archive superseded edge versions
     needs: publish
@@ -74,14 +74,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Connect to staging tailnet
+      - name: Connect to tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
           oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
 
-      - name: Route egress through staging exit node
+      - name: Route egress through exit node
         run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
 
       - name: Archive superseded edge versions

--- a/.github/workflows/distr-publish-pr.yaml
+++ b/.github/workflows/distr-publish-pr.yaml
@@ -36,4 +36,4 @@ jobs:
       registry-host: ${{ vars.DISTR_STAGING_REGISTRY_HOST }}
       oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
       api-base: ${{ vars.DISTR_STAGING_API_BASE }}
-      tailscale: true
+      exit-node: ${{ vars.DISTR_STAGING_EXIT_NODE }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -3,26 +3,58 @@ name: Publish production release to Distr
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing stable release tag to backfill (for example copia-0.60.0)
+        required: true
+        type: string
 
 permissions:
   contents: read
   packages: read
   id-token: write
 
+concurrency:
+  group: distr-publish-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
       chart-version: ${{ steps.version.outputs.chart-version }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - id: version
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+          MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          case "$TAG" in
-            copia-*) echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT" ;;
-            *) echo "Unexpected release tag: $TAG" >&2; exit 1 ;;
-          esac
+          set -euo pipefail
+          # Stable production tags only, which also rejects the prerelease forms
+          # present in the tag list such as copia-0.29.0-beta.
+          if ! printf '%s' "$TAG" | grep -qE '^copia-[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Not a stable production release tag: ${TAG}" >&2
+            exit 1
+          fi
+          if [ "$MANUAL" = true ]; then
+            # A dispatch input is free text, so confirm the tag really is a
+            # published, non-draft, non-prerelease GitHub release before anything
+            # authenticates to a registry.
+            if ! state=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+                --json isDraft,isPrerelease --jq '"\(.isDraft) \(.isPrerelease)"'); then
+              echo "::error::No GitHub release found for tag ${TAG}" >&2
+              exit 1
+            fi
+            if [ "$state" != "false false" ]; then
+              echo "::error::${TAG} is a draft or prerelease (isDraft isPrerelease = ${state})" >&2
+              exit 1
+            fi
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: version
@@ -39,4 +71,5 @@ jobs:
       registry-host: ${{ vars.DISTR_STAGING_REGISTRY_HOST }}
       oci-namespace: ${{ vars.DISTR_STAGING_OCI_NAMESPACE }}
       api-base: ${{ vars.DISTR_STAGING_API_BASE }}
-      tailscale: true
+      ref: ${{ needs.version.outputs.tag }}
+      exit-node: ${{ vars.DISTR_STAGING_EXIT_NODE }}

--- a/.github/workflows/distr-publish-release.yaml
+++ b/.github/workflows/distr-publish-release.yaml
@@ -12,8 +12,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  id-token: write
 
 concurrency:
   group: distr-publish-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
@@ -22,6 +20,8 @@ concurrency:
 jobs:
   version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       chart-version: ${{ steps.version.outputs.chart-version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -31,33 +31,35 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
           MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
+          EVENT_STATE: ${{ github.event.release.draft }} ${{ github.event.release.prerelease }}
         run: |
           set -euo pipefail
-          # Stable production tags only, which also rejects the prerelease forms
-          # present in the tag list such as copia-0.29.0-beta.
           if ! printf '%s' "$TAG" | grep -qE '^copia-[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Not a stable production release tag: ${TAG}" >&2
             exit 1
           fi
           if [ "$MANUAL" = true ]; then
-            # A dispatch input is free text, so confirm the tag really is a
-            # published, non-draft, non-prerelease GitHub release before anything
-            # authenticates to a registry.
             if ! state=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
                 --json isDraft,isPrerelease --jq '"\(.isDraft) \(.isPrerelease)"'); then
               echo "::error::No GitHub release found for tag ${TAG}" >&2
               exit 1
             fi
-            if [ "$state" != "false false" ]; then
-              echo "::error::${TAG} is a draft or prerelease (isDraft isPrerelease = ${state})" >&2
-              exit 1
-            fi
+          else
+            state="$EVENT_STATE"
+          fi
+          if [ "$state" != "false false" ]; then
+            echo "::error::${TAG} is a draft or prerelease (draft prerelease = ${state})" >&2
+            exit 1
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "chart-version=${TAG#copia-}" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: version
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
     # TODO(ENG-20123): all publishing targets Distr staging, which stands in as
     # the production instance until the real one is ready. To add the production
     # instance later, reintroduce a matrix over the two instances. Distr cloud is

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -53,17 +53,9 @@ jobs:
           REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          # The rm is required. `git checkout <ref> -- <path>` overlays, so without
-          # it any chart file deleted since the ref would linger in the package.
           rm -rf charts/copia
           git checkout "$REF" -- charts/copia
 
-          # Prefer the ref's own Distr assets. Base values and the customer
-          # template are written against a specific chart's values.yaml and
-          # values.schema.json, so pairing an old chart with current base values
-          # can set keys that the old schema rejects and break the install.
-          # Tags up to copia-0.60.0 predate charts/copia/distr entirely, and those
-          # are the only ones that need the current assets as a fallback.
           if [ -f charts/copia/distr/values.base.yaml ] \
             && [ -f charts/copia/distr/values.customer.example.yaml ]; then
             echo "Using the Distr assets from ${REF}"
@@ -83,7 +75,9 @@ jobs:
 
       - name: Route egress through exit node
         if: ${{ inputs.exit-node != '' }}
-        run: sudo tailscale set --exit-node="${{ inputs.exit-node }}" --exit-node-allow-lan-access
+        env:
+          EXIT_NODE: ${{ inputs.exit-node }}
+        run: sudo tailscale set --exit-node="$EXIT_NODE" --exit-node-allow-lan-access
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -127,12 +121,6 @@ jobs:
           DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
         run: |
           set -euo pipefail
-          # distr-create-version-action has no upsert or overwrite input, so a
-          # duplicate name fails at the very last step, after the chart and images
-          # have already been pushed. Check first and leave the registry untouched.
-          #
-          # Assign the response separately so a failed request fails this step
-          # rather than piping empty input to jq and reading as "does not exist".
           app=$(curl -fsSL --max-time 30 \
             -H "Authorization: AccessToken ${DISTR_API_TOKEN}" \
             "${API_BASE}/applications/${APP_ID}")

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -15,13 +15,16 @@ on:
       api-base:
         required: true
         type: string
-      tailscale:
-        # When true, join the tailnet and route egress through the staging
-        # exit node so the runner can reach Distr staging inside its VPC.
-        description: Connect to the staging tailnet via a Tailscale exit node
+      ref:
+        description: Git ref whose chart content is published; empty uses the caller's commit
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ''
+      exit-node:
+        description: MagicDNS name of the Tailscale exit node to route egress through
+        required: false
+        type: string
+        default: ''
     secrets:
       DISTR_REGISTRY_PAT:
         required: true
@@ -40,18 +43,47 @@ jobs:
       DST: ${{ inputs.registry-host }}/${{ inputs.oci-namespace }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Connect to staging tailnet
-        if: ${{ inputs.tailscale }}
+      - name: Overlay chart content from the target ref
+        if: ${{ inputs.ref != '' }}
+        env:
+          REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          # The rm is required. `git checkout <ref> -- <path>` overlays, so without
+          # it any chart file deleted since the ref would linger in the package.
+          rm -rf charts/copia
+          git checkout "$REF" -- charts/copia
+
+          # Prefer the ref's own Distr assets. Base values and the customer
+          # template are written against a specific chart's values.yaml and
+          # values.schema.json, so pairing an old chart with current base values
+          # can set keys that the old schema rejects and break the install.
+          # Tags up to copia-0.60.0 predate charts/copia/distr entirely, and those
+          # are the only ones that need the current assets as a fallback.
+          if [ -f charts/copia/distr/values.base.yaml ] \
+            && [ -f charts/copia/distr/values.customer.example.yaml ]; then
+            echo "Using the Distr assets from ${REF}"
+          else
+            echo "::notice::${REF} has no charts/copia/distr; falling back to the assets at ${GITHUB_SHA}"
+            git checkout "$GITHUB_SHA" -- charts/copia/distr
+          fi
+          git --no-pager diff --stat HEAD -- charts/copia | tail -1
+
+      - name: Connect to tailnet
+        if: ${{ inputs.exit-node != '' }}
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
           oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
 
-      - name: Route egress through staging exit node
-        if: ${{ inputs.tailscale }}
-        run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
+      - name: Route egress through exit node
+        if: ${{ inputs.exit-node != '' }}
+        run: sudo tailscale set --exit-node="${{ inputs.exit-node }}" --exit-node-allow-lan-access
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -68,6 +100,47 @@ jobs:
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
           echo "$DISTR_REGISTRY_PAT" | docker login "$REGISTRY_HOST" -u - --password-stdin
           echo "$DISTR_REGISTRY_PAT" | helm registry login "$REGISTRY_HOST" -u - --password-stdin
+
+      - name: Resolve Distr application ID
+        id: app
+        env:
+          API_BASE: ${{ inputs.api-base }}
+          APP_NAME: copia
+          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          APP_ID=$(curl -fsSL --max-time 30 \
+            -H "Authorization: AccessToken ${DISTR_API_TOKEN}" \
+            "${API_BASE}/applications" \
+            | jq -r --arg name "${APP_NAME}" '.[] | select(.name == $name) | .id' | head -n1)
+          if [ -z "${APP_ID}" ] || [ "${APP_ID}" = "null" ]; then
+            echo "::error::Distr application not found: ${APP_NAME}" >&2
+            exit 1
+          fi
+          echo "application-id=${APP_ID}" >> "${GITHUB_OUTPUT}"
+
+      - name: Abort if the version already exists
+        env:
+          API_BASE: ${{ inputs.api-base }}
+          APP_ID: ${{ steps.app.outputs.application-id }}
+          CHART_VERSION: ${{ inputs.chart-version }}
+          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          # distr-create-version-action has no upsert or overwrite input, so a
+          # duplicate name fails at the very last step, after the chart and images
+          # have already been pushed. Check first and leave the registry untouched.
+          #
+          # Assign the response separately so a failed request fails this step
+          # rather than piping empty input to jq and reading as "does not exist".
+          app=$(curl -fsSL --max-time 30 \
+            -H "Authorization: AccessToken ${DISTR_API_TOKEN}" \
+            "${API_BASE}/applications/${APP_ID}")
+          if printf '%s' "$app" \
+              | jq -e --arg v "${CHART_VERSION}" '[.versions[]? | select(.name == $v)] | length > 0' >/dev/null; then
+            echo "::error::ApplicationVersion ${CHART_VERSION} already exists; nothing to publish" >&2
+            exit 1
+          fi
 
       - name: Mirror images to Distr
         run: |
@@ -95,26 +168,6 @@ jobs:
       - name: Point base values at the target registry
         run: sed -i "s#__DISTR_REGISTRY__#${DST}#g" charts/copia/distr/values.base.yaml
 
-      - name: Resolve Distr application ID
-        id: app
-        env:
-          API_BASE: ${{ inputs.api-base }}
-          # One application per instance holds every channel (stable, edge, PR),
-          # differentiated by version name.
-          APP_NAME: copia
-          DISTR_API_TOKEN: ${{ secrets.DISTR_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          APP_ID=$(curl -fsSL --max-time 30 \
-            -H "Authorization: AccessToken ${DISTR_API_TOKEN}" \
-            "${API_BASE}/applications" \
-            | jq -r --arg name "${APP_NAME}" '.[] | select(.name == $name) | .id' | head -n1)
-          if [ -z "${APP_ID}" ] || [ "${APP_ID}" = "null" ]; then
-            echo "::error::Distr application not found: ${APP_NAME}" >&2
-            exit 1
-          fi
-          echo "application-id=${APP_ID}" >> "${GITHUB_OUTPUT}"
-
       - name: Create ApplicationVersion
         uses: distr-sh/distr-create-version-action@f14d2ee8b9750e305b29c6047cc68afbf028e8e7 # v1.6.0
         with:
@@ -127,3 +180,4 @@ jobs:
           chart-version: ${{ inputs.chart-version }}
           base-values-file: ${{ github.workspace }}/charts/copia/distr/values.base.yaml
           template-file: ${{ github.workspace }}/charts/copia/distr/values.customer.example.yaml
+          update-deployments: false


### PR DESCRIPTION
Distr publishing landed in `296f408` on 2026-06-30, so every earlier release is invisible in Distr and a customer cannot adopt it against a version they already run without us cutting a new release first.

`distr-publish-release.yaml` now takes a `workflow_dispatch` `tag` input for any existing stable `copia-X.Y.Z` release, rejecting non-stable tags and any release marked draft or prerelease. The reusable workflow gains a `ref` input, because `checkout` there always built the caller's commit and would otherwise package main's chart under a historical version number. It rebuilds `charts/copia` from the ref, preferring that ref's own `distr` assets and falling back to the current ones only for tags predating them, `copia-0.60.0` and earlier.

I also moved the Distr application lookup ahead of the push steps and added a duplicate-version guard, so a name collision fails before anything is mirrored; `update-deployments` stays `false` so a backfill never moves a customer deployment. Finally the `tailscale` boolean becomes `exit-node`, since `tag:ci` joins one tailnet and the exit node alone picks the destination.

Verified locally that `copia-0.61.0` reproduces its tag exactly and `copia-0.60.0` differs only in the two `distr` files; the PR publish run on this branch passed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production releases can now be started manually with a specified tag.
  * Publishing now supports selecting a source revision and routing runner traffic through a specified exit node.
  * Release workflows now validate stable tags and confirm eligibility before publishing.

* **Bug Fixes**
  * Prevented duplicate publishes by checking whether the chart version already exists before creating a new one.
  * Improved release concurrency handling to avoid overlapping runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->