### PR TITLE
ENG-19760 Attach Distr install guide to ApplicationVersion publishes

### DIFF
--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'charts/copia/**'
+      - 'docs/distr/**'
       - '.github/workflows/distr-publish*.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -168,4 +168,12 @@ jobs:
           chart-version: ${{ inputs.chart-version }}
           base-values-file: ${{ github.workspace }}/charts/copia/distr/values.base.yaml
           template-file: ${{ github.workspace }}/charts/copia/distr/values.customer.example.yaml
+          resources: |
+            [
+              {
+                "name": "Install Guide",
+                "path": "${{ github.workspace }}/docs/distr/install.md",
+                "visibleToCustomers": true
+              }
+            ]
           update-deployments: false

--- a/docs/distr/install.md
+++ b/docs/distr/install.md
@@ -28,11 +28,11 @@ fields keep **Deploy** disabled.
 
 ## Install the Kubernetes agent
 
-Copy the connect command from your deployment page in Distr and run it against your cluster:
+Copy the connect command from your deployment page in Distr and run it against your cluster.
+Distr generates a one-time command that includes credentials — paste it from the portal:
 
 ```bash
-kubectl apply -n copia -f \
-  "https://<your-distr-host>/api/v1/connect?targetId=<uuid>&targetSecret=<secret>"
+kubectl apply -n copia -f "https://<your-distr-host>/api/v1/connect?..."
 ```
 
 This installs the Distr agent with RBAC scoped to the `copia` namespace. The agent registers

--- a/docs/distr/install.md
+++ b/docs/distr/install.md
@@ -1,0 +1,67 @@
+# Install Guide — Copia (Kubernetes Agent)
+
+This guide covers deploying Copia via the Distr Kubernetes agent. For the full self-hosted
+documentation set, see [Copia Self-Hosted Docs](https://docs.copia.io/self-hosted-docs).
+
+## Prerequisites
+
+- A Kubernetes cluster with `kubectl` configured (often provisioned by the infrastructure agent)
+- Network access from the cluster to your Distr host
+- A Distr **Kubernetes deployment target** created for namespace `copia`
+- Application entitlement granted for the Copia application
+
+## Before you deploy
+
+Configure these in the Distr customer portal:
+
+| Item | Where |
+|---|---|
+| **Application entitlement** | Licenses → your org → Application Entitlements |
+| **`CopiaDbPassword`** | Secrets (customer-scoped, not vendor-level) |
+| **`CopiaAdminPassword`** | Secrets |
+| **`ConversionManagerDbPassword`** | Secrets (if using conversion manager) |
+| **Environment variables** | Deployments → your target → Environment tab |
+
+Required environment fields include hostname, database connection settings, and admin user
+details. See the environment template on your deployment for the full list. Empty required
+fields keep **Deploy** disabled.
+
+## Install the Kubernetes agent
+
+Copy the connect command from your deployment page in Distr and run it against your cluster:
+
+```bash
+kubectl apply -n copia -f \
+  "https://<your-distr-host>/api/v1/connect?targetId=<uuid>&targetSecret=<secret>"
+```
+
+This installs the Distr agent with RBAC scoped to the `copia` namespace. The agent registers
+with Distr, pulls the Copia Helm chart and container images using injected registry
+credentials, and runs `helm install`.
+
+## Deploy Copia
+
+1. Assign a published **ApplicationVersion** to your deployment target
+2. Click **Deploy**
+3. Monitor deployment status in the Distr portal
+
+The agent merges three layers of Helm values:
+
+1. Chart defaults (`charts/copia/values.yaml`)
+2. Copia base values (attached to every ApplicationVersion)
+3. Your target-specific values and secrets
+
+## Upgrades
+
+Publishing a new ApplicationVersion does not change running deployments automatically. To
+upgrade, assign your target to the new version in the Distr portal. The agent runs
+`helm upgrade`. Reverting the assignment rolls back.
+
+## Troubleshooting
+
+- **Deploy button disabled** — check entitlements, secrets, and required environment fields
+- **Image pull errors** — confirm the agent is healthy; Distr injects pull credentials for
+  artifacts hosted in the Distr registry
+- **Helm install failures** — review agent logs in the deployment status view
+
+For additional help, see [Copia Self-Hosted Docs](https://docs.copia.io/self-hosted-docs).


### PR DESCRIPTION
Publish customer-facing Kubernetes agent install docs as version resources on each Distr ApplicationVersion created by CI.

<!-- This is a guideline -->

## Description
<!-- Please provide a brief description of the changes being made -->

## Checklist
<!-- Please place an "x" between brackets to mark each relevant box -->

<!-- This Pull Request ... -->
- [ ] Links to Clickup
- [ ] Follows PR title convention (`<label>:ENG-XXXX <description>`)
- [ ] Introduces new tests on the code paths changed
- [ ] Has been manually verified
- [ ] Generates no new console or log warnings/errors (manual check)
- [ ] Documentation added/updated as applicable

## Testing Description
<!-- Please provide a brief description of the type of testing done as applicable -->

<!-- If relevant, please include before and after screenshots or videos of any UI/UX, data-contract, testing or other changes -->
### Before

### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Install Guide” resource to Distr application versions.
  * Added a Kubernetes deployment guide for Copia, including setup, required configuration, upgrades, rollbacks, and troubleshooting.

* **Documentation**
  * Added a new Install Guide page: “Install Guide — Copia (Kubernetes Agent)”.

* **Chores**
  * Expanded edge release triggers to run when Distr documentation under `docs/distr/**` changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->