### PR TITLE
INF-184: make CloudNativePG an optional in-cluster Postgres path.

### DIFF
--- a/.github/scripts/route-via-exit-node.sh
+++ b/.github/scripts/route-via-exit-node.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Resolve the live MagicDNS name of a staging-platform exit node and route through it.
+# EXIT_NODE may be the family prefix (staging-platform) or a numbered host
+# (staging-platform-1). The tailnet host can be unsuffixed or staging-platform-N.
+set -euo pipefail
+
+if [ -z "${EXIT_NODE:-}" ]; then
+  echo "::error::EXIT_NODE is not set" >&2
+  exit 1
+fi
+
+prefix="${EXIT_NODE}"
+if [[ "${prefix}" =~ ^(.+)-[0-9]+$ ]]; then
+  prefix="${BASH_REMATCH[1]}"
+fi
+escaped=$(printf '%s' "${prefix}" | sed 's/[][().^$*+?{|]/\\&/g')
+pattern="^${escaped}(-[0-9]+)?$"
+
+node=""
+for _ in $(seq 1 30); do
+  node=$(tailscale status --json | jq -r --arg re "${pattern}" '
+    [.Peer[]?
+     | select(.Online == true and .ExitNodeOption == true)
+     | .HostName
+     | select(test($re))]
+    | sort
+    | .[0] // empty
+  ')
+  if [ -n "${node}" ]; then
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "${node}" ]; then
+  echo "::error::no online exit node matching ${prefix} or ${prefix}-N" >&2
+  tailscale status
+  exit 1
+fi
+
+echo "Using exit node ${node} (hint was ${EXIT_NODE})"
+sudo tailscale set --exit-node="${node}" --exit-node-allow-lan-access

--- a/.github/workflows/distr-cleanup-pr.yaml
+++ b/.github/workflows/distr-cleanup-pr.yaml
@@ -39,6 +39,10 @@ jobs:
       ARTIFACT_NAME: copia
       MATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.version || format('0.0.0-pr{0}.', github.event.pull_request.number) }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Connect to tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
@@ -47,7 +51,9 @@ jobs:
           tags: tag:ci
 
       - name: Route egress through exit node
-        run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
+        env:
+          EXIT_NODE: ${{ vars.DISTR_STAGING_EXIT_NODE }}
+        run: .github/scripts/route-via-exit-node.sh
 
       - name: Archive matching ApplicationVersions
         env:

--- a/.github/workflows/distr-publish-edge.yaml
+++ b/.github/workflows/distr-publish-edge.yaml
@@ -71,10 +71,14 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     # id-token: write lets the Tailscale action mint an OIDC token for its OAuth
-    # flow; no other scopes are needed since this job does not check out code.
+    # flow. contents: read is inherited so we can check out the exit-node helper.
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Connect to tailnet
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
@@ -83,7 +87,9 @@ jobs:
           tags: tag:ci
 
       - name: Route egress through exit node
-        run: sudo tailscale set --exit-node="${{ vars.DISTR_STAGING_EXIT_NODE }}" --exit-node-allow-lan-access
+        env:
+          EXIT_NODE: ${{ vars.DISTR_STAGING_EXIT_NODE }}
+        run: .github/scripts/route-via-exit-node.sh
 
       - name: Archive superseded edge versions
         # Best-effort: publishing already succeeded, and the next edge run

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -21,7 +21,9 @@ on:
         type: string
         default: ''
       exit-node:
-        description: MagicDNS name of the Tailscale exit node to route egress through
+        description: >
+          Staging exit-node hostname prefix (e.g. staging-platform). The live MagicDNS
+          name may be unsuffixed or staging-platform-N; CI resolves it from the tailnet.
         required: false
         type: string
         default: ''
@@ -65,35 +67,6 @@ jobs:
           fi
           git --no-pager diff --stat HEAD -- charts/copia | tail -1
 
-      # Install Helm before the exit node. azure/setup-helm downloads from
-      # get.helm.sh, which MagicDNS/exit-node DNS often cannot resolve
-      # (getaddrinfo EAI_AGAIN).
-      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.21.2
-
-      # GHCR is public. Login and pull before the exit node; staging-platform-1
-      # cannot reach ghcr.io (docker login times out with context deadline).
-      - name: Log in to GHCR
-        env:
-          GHCR_TOKEN: ${{ github.token }}
-          GHCR_ACTOR: ${{ github.actor }}
-        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
-
-      - name: Pull chart images from GHCR
-        run: |
-          set -euo pipefail
-          helm template mirror charts/copia --set conversion_manager_service.enabled=true \
-            > /tmp/rendered.yaml
-          grep -oE 'ghcr\.io/copia-automation/[A-Za-z0-9._/-]+:[A-Za-z0-9._+-]+' \
-            /tmp/rendered.yaml | sort -u > /tmp/srcs.txt
-          test -s /tmp/srcs.txt
-          while IFS= read -r src; do
-            dst="${DST}/${src#ghcr.io/copia-automation/}"
-            docker pull "$src"
-            docker tag "$src" "$dst"
-          done < /tmp/srcs.txt
-
       - name: Connect to tailnet
         if: ${{ inputs.exit-node != '' }}
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
@@ -106,14 +79,23 @@ jobs:
         if: ${{ inputs.exit-node != '' }}
         env:
           EXIT_NODE: ${{ inputs.exit-node }}
-        run: sudo tailscale set --exit-node="$EXIT_NODE" --exit-node-allow-lan-access
+        run: |
+          set -euo pipefail
+          .github/scripts/route-via-exit-node.sh
 
-      - name: Log in to Distr registry
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.21.2
+
+      - name: Log in to registries
         env:
           DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
           REGISTRY_HOST: ${{ inputs.registry-host }}
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
           echo "$DISTR_REGISTRY_PAT" | docker login "$REGISTRY_HOST" -u - --password-stdin
           echo "$DISTR_REGISTRY_PAT" | helm registry login "$REGISTRY_HOST" -u - --password-stdin
 
@@ -152,12 +134,17 @@ jobs:
             exit 1
           fi
 
-      - name: Push mirrored images to Distr
+      - name: Mirror images to Distr
         run: |
           set -euo pipefail
+          helm template mirror charts/copia --set conversion_manager_service.enabled=true > /tmp/rendered.yaml
+          grep -oE 'ghcr\.io/copia-automation/[A-Za-z0-9._/-]+:[A-Za-z0-9._+-]+' /tmp/rendered.yaml | sort -u > /tmp/srcs.txt
+          test -s /tmp/srcs.txt
           while IFS= read -r src; do
             dst="${DST}/${src#ghcr.io/copia-automation/}"
             if docker manifest inspect "$dst" >/dev/null 2>&1; then continue; fi
+            docker pull "$src"
+            docker tag "$src" "$dst"
             docker push "$dst"
           done < /tmp/srcs.txt
 

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -65,6 +65,13 @@ jobs:
           fi
           git --no-pager diff --stat HEAD -- charts/copia | tail -1
 
+      # Install Helm before the exit node. azure/setup-helm downloads from
+      # get.helm.sh, which MagicDNS/exit-node DNS often cannot resolve
+      # (getaddrinfo EAI_AGAIN).
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.21.2
+
       - name: Connect to tailnet
         if: ${{ inputs.exit-node != '' }}
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
@@ -78,10 +85,6 @@ jobs:
         env:
           EXIT_NODE: ${{ inputs.exit-node }}
         run: sudo tailscale set --exit-node="$EXIT_NODE" --exit-node-allow-lan-access
-
-      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.21.2
 
       - name: Log in to registries
         env:

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -174,6 +174,11 @@ jobs:
                 "name": "Install Guide",
                 "path": "${{ github.workspace }}/docs/distr/install.md",
                 "visibleToCustomers": true
+              },
+              {
+                "name": "CloudNativePG Config",
+                "path": "${{ github.workspace }}/docs/distr/cloudnativepg.md",
+                "visibleToCustomers": true
               }
             ]
           update-deployments: false

--- a/.github/workflows/distr-publish.yaml
+++ b/.github/workflows/distr-publish.yaml
@@ -72,6 +72,28 @@ jobs:
         with:
           version: v3.21.2
 
+      # GHCR is public. Login and pull before the exit node; staging-platform-1
+      # cannot reach ghcr.io (docker login times out with context deadline).
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_ACTOR: ${{ github.actor }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+
+      - name: Pull chart images from GHCR
+        run: |
+          set -euo pipefail
+          helm template mirror charts/copia --set conversion_manager_service.enabled=true \
+            > /tmp/rendered.yaml
+          grep -oE 'ghcr\.io/copia-automation/[A-Za-z0-9._/-]+:[A-Za-z0-9._+-]+' \
+            /tmp/rendered.yaml | sort -u > /tmp/srcs.txt
+          test -s /tmp/srcs.txt
+          while IFS= read -r src; do
+            dst="${DST}/${src#ghcr.io/copia-automation/}"
+            docker pull "$src"
+            docker tag "$src" "$dst"
+          done < /tmp/srcs.txt
+
       - name: Connect to tailnet
         if: ${{ inputs.exit-node != '' }}
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
@@ -86,15 +108,12 @@ jobs:
           EXIT_NODE: ${{ inputs.exit-node }}
         run: sudo tailscale set --exit-node="$EXIT_NODE" --exit-node-allow-lan-access
 
-      - name: Log in to registries
+      - name: Log in to Distr registry
         env:
           DISTR_REGISTRY_PAT: ${{ secrets.DISTR_REGISTRY_PAT }}
           REGISTRY_HOST: ${{ inputs.registry-host }}
-          GHCR_TOKEN: ${{ github.token }}
-          GHCR_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
           echo "$DISTR_REGISTRY_PAT" | docker login "$REGISTRY_HOST" -u - --password-stdin
           echo "$DISTR_REGISTRY_PAT" | helm registry login "$REGISTRY_HOST" -u - --password-stdin
 
@@ -133,17 +152,12 @@ jobs:
             exit 1
           fi
 
-      - name: Mirror images to Distr
+      - name: Push mirrored images to Distr
         run: |
           set -euo pipefail
-          helm template mirror charts/copia --set conversion_manager_service.enabled=true > /tmp/rendered.yaml
-          grep -oE 'ghcr\.io/copia-automation/[A-Za-z0-9._/-]+:[A-Za-z0-9._+-]+' /tmp/rendered.yaml | sort -u > /tmp/srcs.txt
-          test -s /tmp/srcs.txt
           while IFS= read -r src; do
             dst="${DST}/${src#ghcr.io/copia-automation/}"
             if docker manifest inspect "$dst" >/dev/null 2>&1; then continue; fi
-            docker pull "$src"
-            docker tag "$src" "$dst"
             docker push "$dst"
           done < /tmp/srcs.txt
 

--- a/charts/copia/distr/values.customer.example.yaml
+++ b/charts/copia/distr/values.customer.example.yaml
@@ -27,7 +27,7 @@ cloudnativePG:
   instances: 1
   storage:
     size: 50Gi
-    # storageClass: gp3
+    storageClass: single
 copia:
   config:
     server:

--- a/charts/copia/distr/values.customer.example.yaml
+++ b/charts/copia/distr/values.customer.example.yaml
@@ -19,9 +19,9 @@ ingress:
       hosts:
         - copia.example.com
 # In-cluster Postgres via CloudNativePG. Requires the operator and CRDs already
-# on the cluster (this chart does not install them). When enabled, HOST and
-# DB_HOST below are ignored; Copia and conversion-manager use <clusterName>-rw:5432.
-# See the "CloudNativePG Config" guide.
+# on the cluster (this chart does not install them). When enabled, remove HOST
+# and DB_HOST below; the chart uses <clusterName>-rw:5432 and fails if those
+# fields still point at an external server. See the "CloudNativePG Config" guide.
 cloudnativePG:
   enabled: false
   instances: 1
@@ -34,7 +34,7 @@ copia:
       DOMAIN: copia.example.com
       ROOT_URL: https://copia.example.com/
     database:
-      # Required for an existing Postgres. Ignored when cloudnativePG.enabled is true.
+      # Required for an existing Postgres. Remove this key when using CloudNativePG.
       HOST: postgres.example.com:5432
       NAME: copia
       USER: copia
@@ -51,7 +51,7 @@ copia:
       # PASSWD: "{{ .Secrets.SmtpPassword }}"
 conversion_manager_service:
   configmap:
-    # Ignored when cloudnativePG.enabled is true.
+    # Required for an existing Postgres. Remove this key when using CloudNativePG.
     DB_HOST: postgres.example.com:5432
     DB_NAME: conversion_manager
     DB_USER: conversion_manager

--- a/charts/copia/distr/values.customer.example.yaml
+++ b/charts/copia/distr/values.customer.example.yaml
@@ -18,12 +18,23 @@ ingress:
     - secretName: copia-tls
       hosts:
         - copia.example.com
+# In-cluster Postgres via CloudNativePG. Requires the operator and CRDs already
+# on the cluster (this chart does not install them). When enabled, HOST and
+# DB_HOST below are ignored; Copia and conversion-manager use <clusterName>-rw:5432.
+# See the "CloudNativePG Config" guide.
+cloudnativePG:
+  enabled: false
+  instances: 1
+  storage:
+    size: 50Gi
+    # storageClass: gp3
 copia:
   config:
     server:
       DOMAIN: copia.example.com
       ROOT_URL: https://copia.example.com/
     database:
+      # Required for an existing Postgres. Ignored when cloudnativePG.enabled is true.
       HOST: postgres.example.com:5432
       NAME: copia
       USER: copia
@@ -40,6 +51,7 @@ copia:
       # PASSWD: "{{ .Secrets.SmtpPassword }}"
 conversion_manager_service:
   configmap:
+    # Ignored when cloudnativePG.enabled is true.
     DB_HOST: postgres.example.com:5432
     DB_NAME: conversion_manager
     DB_USER: conversion_manager

--- a/charts/copia/templates/_helpers.tpl
+++ b/charts/copia/templates/_helpers.tpl
@@ -183,10 +183,40 @@ copia
 
 {{/*
 host:port used by Copia and conversion-manager. When CloudNativePG is enabled this
-is the Cluster read-write Service, even if copia.config.database.HOST is set.
+is the Cluster read-write Service. A customer-set HOST/DB_HOST is an error unless
+it is empty, a localhost placeholder (chart default), or already the RW Service.
 */}}
+{{- define "copia.cnpg.isPlaceholderHost" -}}
+{{- $h := . | toString | trim | lower -}}
+{{- if or (eq $h "") (eq $h "localhost") (hasPrefix "localhost:" $h) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "copia.cnpg.validateHosts" -}}
+{{- if eq "true" (include "copia.cnpg.enabled" .) -}}
+{{- $expected := printf "%s-rw:5432" (include "copia.cnpg.clusterName" .) -}}
+{{- $host := "" -}}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.HOST -}}
+{{- $host = .Values.copia.config.database.HOST | toString -}}
+{{- end -}}
+{{- if and $host (ne $host $expected) (ne (include "copia.cnpg.isPlaceholderHost" $host) "true") -}}
+{{- fail "cloudnativePG.enabled is true; omit copia.config.database.HOST." -}}
+{{- end -}}
+{{- $cmHost := "" -}}
+{{- $cm := .Values.conversion_manager_service -}}
+{{- if and $cm $cm.configmap $cm.configmap.DB_HOST -}}
+{{- $cmHost = $cm.configmap.DB_HOST | toString -}}
+{{- end -}}
+{{- if and $cmHost (ne $cmHost $expected) (ne (include "copia.cnpg.isPlaceholderHost" $cmHost) "true") -}}
+{{- fail "cloudnativePG.enabled is true; omit conversion_manager_service.configmap.DB_HOST." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "copia.database.hostPort" -}}
 {{- if eq "true" (include "copia.cnpg.enabled" .) }}
+{{- $_ := include "copia.cnpg.validateHosts" . }}
 {{- printf "%s-rw:5432" (include "copia.cnpg.clusterName" .) }}
 {{- else if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.HOST }}
 {{- .Values.copia.config.database.HOST }}

--- a/charts/copia/templates/_helpers.tpl
+++ b/charts/copia/templates/_helpers.tpl
@@ -135,3 +135,107 @@ Selector labels
 app.kubernetes.io/name: {{ include "app.conversion-manager.name" . }}
 app.kubernetes.io/instance: {{ include "app.conversion-manager.name" . }}
 {{- end -}}
+
+{{/*
+Return "true" when the chart should render a CloudNativePG Cluster.
+*/}}
+{{- define "copia.cnpg.enabled" -}}
+{{- if and .Values.cloudnativePG .Values.cloudnativePG.enabled -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+CloudNativePG Cluster object name. DNS label, kept short enough for -rw/-r suffixes.
+*/}}
+{{- define "copia.cnpg.clusterName" -}}
+{{- if and .Values.cloudnativePG .Values.cloudnativePG.clusterName }}
+{{- .Values.cloudnativePG.clusterName | trunc 51 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-pg" (include "app.fullname" .) | trunc 51 | trimSuffix "-" }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Postgres application owner. Defaults to copia. Reserved CNPG roles are rejected.
+*/}}
+{{- define "copia.database.user" -}}
+{{- $user := "copia" }}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.USER }}
+{{- $user = .Values.copia.config.database.USER }}
+{{- end }}
+{{- if and (eq "true" (include "copia.cnpg.enabled" .)) (or (eq $user "postgres") (eq $user "streaming_replica")) }}
+{{- fail "cloudnativePG.enabled cannot use database USER postgres or streaming_replica (reserved by CloudNativePG)." }}
+{{- end }}
+{{- $user }}
+{{- end -}}
+
+{{/*
+Postgres database name for Copia. Defaults to copia.
+*/}}
+{{- define "copia.database.name" -}}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.NAME }}
+{{- .Values.copia.config.database.NAME }}
+{{- else }}
+copia
+{{- end }}
+{{- end -}}
+
+{{/*
+host:port used by Copia and conversion-manager. When CloudNativePG is enabled this
+is the Cluster read-write Service, even if copia.config.database.HOST is set.
+*/}}
+{{- define "copia.database.hostPort" -}}
+{{- if eq "true" (include "copia.cnpg.enabled" .) }}
+{{- printf "%s-rw:5432" (include "copia.cnpg.clusterName" .) }}
+{{- else if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.HOST }}
+{{- .Values.copia.config.database.HOST }}
+{{- end }}
+{{- end -}}
+
+{{- define "copia.database.host" -}}
+{{- $hostPort := include "copia.database.hostPort" . | trim }}
+{{- $parts := splitList ":" $hostPort }}
+{{- index $parts 0 }}
+{{- end -}}
+
+{{- define "copia.database.port" -}}
+{{- $hostPort := include "copia.database.hostPort" . | trim }}
+{{- $parts := splitList ":" $hostPort }}
+{{- if eq (len $parts) 2 }}{{ index $parts 1 }}{{ else }}5432{{ end }}
+{{- end -}}
+
+{{/*
+Return "true" when conversion-manager should get a CNPG Database and role.
+*/}}
+{{- define "copia.cnpg.conversionManager.enabled" -}}
+{{- if eq "true" (include "copia.cnpg.enabled" .) -}}
+{{- if and .Values.conversion_manager_service .Values.conversion_manager_service.enabled -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+conversion-manager role name. Remaps reserved postgres/streaming_replica names.
+*/}}
+{{- define "copia.cnpg.conversionManager.user" -}}
+{{- $user := "conversion_manager" }}
+{{- $cm := .Values.conversion_manager_service }}
+{{- if and $cm $cm.configmap $cm.configmap.DB_USER }}
+{{- $user = $cm.configmap.DB_USER }}
+{{- end }}
+{{- if or (eq $user "postgres") (eq $user "streaming_replica") }}
+{{- $user = "conversion_manager" }}
+{{- end }}
+{{- $user }}
+{{- end -}}
+
+{{- define "copia.cnpg.conversionManager.database" -}}
+{{- $cm := .Values.conversion_manager_service }}
+{{- if and $cm $cm.configmap $cm.configmap.DB_NAME }}
+{{- $cm.configmap.DB_NAME }}
+{{- else }}
+conversion_manager
+{{- end }}
+{{- end -}}

--- a/charts/copia/templates/_wait_postgres.tpl
+++ b/charts/copia/templates/_wait_postgres.tpl
@@ -1,0 +1,56 @@
+{{/*
+Init container that blocks until Postgres accepts connections and the target
+database exists. Used so Copia and conversion-manager do not start during CNPG
+initdb.
+*/}}
+{{- define "copia.waitPostgres.initContainer" -}}
+- name: {{ .name }}
+  image: postgres:16-alpine
+  imagePullPolicy: IfNotPresent
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+      max_attempts=180
+      attempt=0
+      until pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -t 3; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "postgres readiness timeout (${PGHOST}:${PGPORT}/${PGDATABASE})"
+          exit 1
+        fi
+        echo "waiting for postgres ${PGHOST}:${PGPORT}/${PGDATABASE} (${attempt}/${max_attempts})"
+        sleep 2
+      done
+      attempt=0
+      until psql -tAc "SELECT 1" | grep -q 1; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "postgres login timeout (${PGHOST}:${PGPORT}/${PGDATABASE})"
+          exit 1
+        fi
+        echo "waiting for database ${PGDATABASE} (${attempt}/${max_attempts})"
+        sleep 2
+      done
+      echo "postgres is ready"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  env:
+    - name: PGHOST
+      value: {{ .host | quote }}
+    - name: PGPORT
+      value: {{ .port | quote }}
+    - name: PGUSER
+      value: {{ .user | quote }}
+    - name: PGPASSWORD
+      value: {{ .password | quote }}
+    - name: PGDATABASE
+      value: {{ .database | quote }}
+    - name: PGSSLMODE
+      value: {{ .sslMode | default "prefer" | quote }}
+{{- end -}}

--- a/charts/copia/templates/cnpg-cluster.yaml
+++ b/charts/copia/templates/cnpg-cluster.yaml
@@ -1,0 +1,115 @@
+{{- if eq "true" (include "copia.cnpg.enabled" .) }}
+{{- $requireCRD := true }}
+{{- if and .Values.cloudnativePG (hasKey .Values.cloudnativePG "requireCRD") }}
+{{- $requireCRD = .Values.cloudnativePG.requireCRD }}
+{{- end }}
+{{- if and $requireCRD (not (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1")) }}
+{{- fail "cloudnativePG.enabled requires CloudNativePG CRDs (postgresql.cnpg.io/v1). Install the operator first." }}
+{{- end }}
+{{- $db := dict }}
+{{- if and .Values.copia .Values.copia.config }}
+{{- $db = .Values.copia.config.database | default dict }}
+{{- end }}
+{{- if not $db.PASSWD }}
+{{- fail "cloudnativePG.enabled requires copia.config.database.PASSWD (bootstrap owner password)." }}
+{{- end }}
+{{- $clusterName := include "copia.cnpg.clusterName" . }}
+{{- $appSecret := printf "%s-app" $clusterName }}
+{{- $cmSecret := printf "%s-conversion-manager" $clusterName }}
+{{- $size := "20Gi" }}
+{{- if and .Values.cloudnativePG.storage .Values.cloudnativePG.storage.size }}
+{{- $size = .Values.cloudnativePG.storage.size }}
+{{- end }}
+{{- $storage := dict "size" $size }}
+{{- if and .Values.cloudnativePG.storage .Values.cloudnativePG.storage.storageClass }}
+{{- $_ := set $storage "storageClass" .Values.cloudnativePG.storage.storageClass }}
+{{- end }}
+{{- $initdb := dict
+      "database" (include "copia.database.name" .)
+      "owner" (include "copia.database.user" .)
+      "secret" (dict "name" $appSecret)
+}}
+{{- $spec := dict
+      "instances" (int (.Values.cloudnativePG.instances | default 1))
+      "imageName" (.Values.cloudnativePG.imageName | default "ghcr.io/cloudnative-pg/postgresql:16")
+      "enableSuperuserAccess" false
+      "storage" $storage
+      "bootstrap" (dict "initdb" $initdb)
+}}
+{{- if .Values.cloudnativePG.imagePullPolicy }}
+{{- $_ := set $spec "imagePullPolicy" .Values.cloudnativePG.imagePullPolicy }}
+{{- end }}
+{{- if and .Values.cloudnativePG.imagePullSecrets (gt (len .Values.cloudnativePG.imagePullSecrets) 0) }}
+{{- $_ := set $spec "imagePullSecrets" .Values.cloudnativePG.imagePullSecrets }}
+{{- end }}
+{{- if and .Values.cloudnativePG.resources (gt (len .Values.cloudnativePG.resources) 0) }}
+{{- $_ := set $spec "resources" .Values.cloudnativePG.resources }}
+{{- end }}
+{{- if eq "true" (include "copia.cnpg.conversionManager.enabled" .) }}
+{{- if not (and .Values.conversion_manager_service.secret .Values.conversion_manager_service.secret.DB_PASSWORD) }}
+{{- fail "cloudnativePG with conversion-manager requires conversion_manager_service.secret.DB_PASSWORD." }}
+{{- end }}
+{{- $role := dict
+      "name" (include "copia.cnpg.conversionManager.user" .)
+      "ensure" "present"
+      "login" true
+      "passwordSecret" (dict "name" $cmSecret)
+}}
+{{- $_ := set $spec "managed" (dict "roles" (list $role)) }}
+{{- end }}
+{{- $spec = mergeOverwrite $spec (.Values.cloudnativePG.extraSpec | default dict) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $appSecret }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+stringData:
+  username: {{ include "copia.database.user" . | quote }}
+  password: {{ .Values.copia.config.database.PASSWD | quote }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ $clusterName }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- if .Values.cloudnativePG.keepOnDelete }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- if eq "true" (include "copia.cnpg.conversionManager.enabled" .) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $cmSecret }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+stringData:
+  username: {{ include "copia.cnpg.conversionManager.user" . | quote }}
+  password: {{ .Values.conversion_manager_service.secret.DB_PASSWORD | quote }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: {{ $clusterName }}-conversion-manager
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- if .Values.cloudnativePG.keepOnDelete }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  name: {{ include "copia.cnpg.conversionManager.database" . }}
+  owner: {{ include "copia.cnpg.conversionManager.user" . }}
+  cluster:
+    name: {{ $clusterName }}
+{{- end }}
+{{- end }}

--- a/charts/copia/templates/cnpg-cluster.yaml
+++ b/charts/copia/templates/cnpg-cluster.yaml
@@ -13,6 +13,7 @@
 {{- if not $db.PASSWD }}
 {{- fail "cloudnativePG.enabled requires copia.config.database.PASSWD (bootstrap owner password)." }}
 {{- end }}
+{{- $_ := include "copia.cnpg.validateHosts" . }}
 {{- $clusterName := include "copia.cnpg.clusterName" . }}
 {{- $appSecret := printf "%s-app" $clusterName }}
 {{- $cmSecret := printf "%s-conversion-manager" $clusterName }}

--- a/charts/copia/templates/conversion-manager-configmap.yaml
+++ b/charts/copia/templates/conversion-manager-configmap.yaml
@@ -1,4 +1,10 @@
 {{- if and .Values.conversion_manager_service.configmap (eq .Values.conversion_manager_service.enabled true)}}
+{{- $cm := deepCopy .Values.conversion_manager_service.configmap }}
+{{- if eq "true" (include "copia.cnpg.enabled" .) }}
+  {{- $_ := set $cm "DB_HOST" (include "copia.database.hostPort" .) }}
+  {{- $_ := set $cm "DB_USER" (include "copia.cnpg.conversionManager.user" .) }}
+  {{- $_ := set $cm "DB_NAME" (include "copia.cnpg.conversionManager.database" .) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,7 +12,7 @@ metadata:
   labels:
     {{- include "app.conversion-manager.labels" . | nindent 4 }}
 data:
-  {{- range $key, $value := .Values.conversion_manager_service.configmap }}
+  {{- range $key, $value := $cm }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}

--- a/charts/copia/templates/conversion-manager-deployment.yaml
+++ b/charts/copia/templates/conversion-manager-deployment.yaml
@@ -46,6 +46,22 @@ spec:
       {{- if .Values.conversion_manager_service.deployment.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.conversion_manager_service.deployment.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if eq "true" (include "copia.cnpg.conversionManager.enabled" .) }}
+      {{- $sslMode := "prefer" }}
+      {{- if and .Values.copia.config.database .Values.copia.config.database.SSL_MODE }}
+      {{- $sslMode = .Values.copia.config.database.SSL_MODE }}
+      {{- end }}
+      initContainers:
+        {{- include "copia.waitPostgres.initContainer" (dict
+          "name" "wait-postgres"
+          "host" (include "copia.database.host" .)
+          "port" (include "copia.database.port" .)
+          "user" (include "copia.cnpg.conversionManager.user" .)
+          "password" .Values.conversion_manager_service.secret.DB_PASSWORD
+          "database" (include "copia.cnpg.conversionManager.database" .)
+          "sslMode" $sslMode
+        ) | nindent 8 }}
+      {{- end }}
       containers:
         - name: "conversion-manager"
           image: "{{ include "cm.image" . }}"

--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -55,28 +55,19 @@ spec:
       {{- if or $waitPg $autoGen }}
       initContainers:
         {{- if $waitPg }}
-        - name: {{ .Chart.Name }}-init
-          image: postgres:latest
-          imagePullPolicy: Always
-          command: ['psql', '-c', '\q']
-          resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-          env:
-            - name: PGHOST
-              value: {{ include "copia.database.host" . | quote }}
-            - name: PGPORT
-              value: {{ include "copia.database.port" . | quote }}
-            - name: PGUSER
-              value: {{ include "copia.database.user" . | quote }}
-            - name: PGPASSWORD
-              value: {{ .Values.copia.config.database.PASSWD | quote }}
-            - name: PGDATABASE
-              value: {{ include "copia.database.name" . | quote }}
+        {{- $sslMode := "prefer" }}
+        {{- if and .Values.copia.config.database .Values.copia.config.database.SSL_MODE }}
+        {{- $sslMode = .Values.copia.config.database.SSL_MODE }}
+        {{- end }}
+        {{- include "copia.waitPostgres.initContainer" (dict
+          "name" (printf "%s-init" .Chart.Name)
+          "host" (include "copia.database.host" .)
+          "port" (include "copia.database.port" .)
+          "user" (include "copia.database.user" .)
+          "password" .Values.copia.config.database.PASSWD
+          "database" (include "copia.database.name" .)
+          "sslMode" $sslMode
+        ) | nindent 8 }}
         {{- end }}
         {{- if $autoGen }}
         - name: render-app-ini

--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -48,10 +48,13 @@ spec:
       securityContext:
         fsGroup: 1000
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
-      {{- $autoGen := and (hasKey .Values.copia "config") (and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled) }}
-      {{- if or (and .Values.copia.config .Values.deployment.preflight) $autoGen }}
+      {{- $secretsOn := and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+      {{- $autoGen := and (hasKey .Values.copia "config") $secretsOn }}
+      {{- $cnpgOn := eq "true" (include "copia.cnpg.enabled" .) }}
+      {{- $waitPg := and .Values.copia.config (or .Values.deployment.preflight $cnpgOn) }}
+      {{- if or $waitPg $autoGen }}
       initContainers:
-        {{- if and .Values.copia.config .Values.deployment.preflight }}
+        {{- if $waitPg }}
         - name: {{ .Chart.Name }}-init
           image: postgres:latest
           imagePullPolicy: Always
@@ -65,13 +68,15 @@ spec:
               memory: 128Mi
           env:
             - name: PGHOST
-              value: {{ .Values.copia.config.database.HOST }}
+              value: {{ include "copia.database.host" . | quote }}
+            - name: PGPORT
+              value: {{ include "copia.database.port" . | quote }}
             - name: PGUSER
-              value: {{ .Values.copia.config.database.USER }}
+              value: {{ include "copia.database.user" . | quote }}
             - name: PGPASSWORD
-              value: {{ .Values.copia.config.database.PASSWD }}
+              value: {{ .Values.copia.config.database.PASSWD | quote }}
             - name: PGDATABASE
-              value: {{ .Values.copia.config.database.NAME }}
+              value: {{ include "copia.database.name" . | quote }}
         {{- end }}
         {{- if $autoGen }}
         - name: render-app-ini

--- a/charts/copia/templates/copia-secret.yaml
+++ b/charts/copia/templates/copia-secret.yaml
@@ -11,6 +11,22 @@ stringData:
     {{- /* autogenerate app.ini */ -}}
     {{- $autoGen := and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled -}}
     {{- $cfg := deepCopy .Values.copia.config -}}
+    {{- if eq "true" (include "copia.cnpg.enabled" .) }}
+      {{- if not (hasKey $cfg "database") }}
+        {{- $_ := set $cfg "database" dict }}
+      {{- end }}
+      {{- $db := index $cfg "database" }}
+      {{- $_ := set $db "HOST" (include "copia.database.hostPort" .) }}
+      {{- if not (index $db "DB_TYPE") }}
+        {{- $_ := set $db "DB_TYPE" "postgres" }}
+      {{- end }}
+      {{- if not (index $db "USER") }}
+        {{- $_ := set $db "USER" (include "copia.database.user" .) }}
+      {{- end }}
+      {{- if not (index $db "NAME") }}
+        {{- $_ := set $db "NAME" (include "copia.database.name" .) }}
+      {{- end }}
+    {{- end }}
     {{- if $autoGen -}}
       {{- $autoGenKeys := list
             (list "security"           "INTERNAL_TOKEN")

--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -83,18 +83,14 @@ spec:
           image: postgres:15-alpine
           command: ["/bin/sh", "/scripts/bootstrap.sh"]
           env:
-            {{- $parts := splitList ":" .Values.copia.config.database.HOST }}
-            {{- $pgHost := index $parts 0 }}
-            {{- $pgPort := "5432" }}
-            {{- if eq (len $parts) 2 }}{{ $pgPort = index $parts 1 }}{{ end }}
             - name: PGHOST
-              value: {{ $pgHost | quote }}
+              value: {{ include "copia.database.host" . | quote }}
             - name: PGPORT
-              value: {{ $pgPort | quote }}
+              value: {{ include "copia.database.port" . | quote }}
             - name: PGUSER
-              value: {{ .Values.copia.config.database.USER | quote }}
+              value: {{ include "copia.database.user" . | quote }}
             - name: PGDATABASE
-              value: {{ .Values.copia.config.database.NAME | quote }}
+              value: {{ include "copia.database.name" . | quote }}
             - name: PGPASSWORD
               value: {{ .Values.copia.config.database.PASSWD | quote }}
             - name: ADMIN_USERNAME

--- a/charts/copia/templates/troubleshoot/_shared.yaml
+++ b/charts/copia/templates/troubleshoot/_shared.yaml
@@ -2,18 +2,16 @@
 - clusterInfo: {}
 - clusterResources: {}
 
-{{- if .Values.copia -}}
-{{- if .Values.copia.config -}}
-{{ if .Values.copia.config.database }}
-{{ $user := .Values.copia.config.database.USER }}
-{{ $passwd := .Values.copia.config.database.PASSWD }}
-{{ $host := .Values.copia.config.database.HOST }}
-{{ $name := .Values.copia.config.database.NAME }}
+{{- $cnpg := eq "true" (include "copia.cnpg.enabled" .) }}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database (not $cnpg) }}
+{{- $user := .Values.copia.config.database.USER }}
+{{- $passwd := .Values.copia.config.database.PASSWD }}
+{{- $host := include "copia.database.host" . }}
+{{- $port := include "copia.database.port" . }}
+{{- $name := .Values.copia.config.database.NAME }}
 - postgres:
     collectorName: postgresql
-    uri: "postgresql://{{ $user }}:{{ $passwd }}@{{ $host }}:5432/{{ $name }}"
-{{- end -}}
-{{- end -}}
+    uri: "postgresql://{{ $user }}:{{ $passwd }}@{{ $host }}:{{ $port }}/{{ $name }}"
 {{- end -}}
 
 {{- end -}}
@@ -33,9 +31,17 @@
 {{- end -}}
 {{- end -}}
 
-{{- if .Values.copia -}}
-{{- if .Values.copia.config -}}
-{{ if .Values.copia.config.database }}
+{{- $cnpg := eq "true" (include "copia.cnpg.enabled" .) }}
+{{- if $cnpg }}
+- customResourceDefinition:
+    checkName: CloudNativePG Cluster CRD
+    customResourceDefinitionName: clusters.postgresql.cnpg.io
+    outcomes:
+      - fail:
+          message: CloudNativePG CRDs are not installed. Install the operator before enabling cloudnativePG.
+      - pass:
+          message: CloudNativePG Cluster CRD is installed
+{{- else if and .Values.copia .Values.copia.config .Values.copia.config.database }}
 - postgres:
     checkName: Test Database Connection
     collectorName: postgresql
@@ -45,7 +51,6 @@
           message: Cannot connect to PostgreSQL server.
       - pass:
           message: The PostgreSQL server is accessible.
-{{- end -}}
 {{- end -}}
 
 {{- if .Values.ingress -}}
@@ -66,8 +71,6 @@
           message: Defined Ingress Class is available
 {{- end -}}
 {{- end -}}
-{{- end -}}
-
 {{- end -}}
 
 {{- end -}}

--- a/charts/copia/tests/cnpg_cluster_test.yaml
+++ b/charts/copia/tests/cnpg_cluster_test.yaml
@@ -22,6 +22,28 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "copia.config.database.PASSWD"
+  - it: fails when enabled with an external database HOST
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      copia.config.database.PASSWD: s3cret
+      copia.config.database.HOST: postgres.example.com:5432
+    asserts:
+      - failedTemplate:
+          errorPattern: "omit copia.config.database.HOST"
+  - it: fails when enabled with an external conversion-manager DB_HOST
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      copia.config.database.PASSWD: s3cret
+      conversion_manager_service.configmap.DB_HOST: postgres.example.com:5432
+    asserts:
+      - failedTemplate:
+          errorPattern: "omit conversion_manager_service.configmap.DB_HOST"
   - it: renders owner secret and Cluster when enabled
     capabilities:
       apiVersions:

--- a/charts/copia/tests/cnpg_cluster_test.yaml
+++ b/charts/copia/tests/cnpg_cluster_test.yaml
@@ -65,6 +65,21 @@ tests:
           apiVersion: postgresql.cnpg.io/v1
           kind: Cluster
           any: true
+  - it: Cluster defaults storageClass to single
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.PASSWD: s3cret
+    documentSelector:
+      path: kind
+      value: Cluster
+    asserts:
+      - equal:
+          path: spec.storage.storageClass
+          value: single
   - it: Cluster uses bootstrap owner and storage from values
     capabilities:
       apiVersions:
@@ -103,6 +118,21 @@ tests:
       - equal:
           path: spec.bootstrap.initdb.secret.name
           value: copia-pg-app
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+  - it: keepOnDelete annotates Cluster so Helm will not delete it
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      cloudnativePG.keepOnDelete: true
+      copia.config.database.PASSWD: s3cret
+    documentSelector:
+      path: kind
+      value: Cluster
+    asserts:
       - equal:
           path: metadata.annotations["helm.sh/resource-policy"]
           value: keep

--- a/charts/copia/tests/cnpg_cluster_test.yaml
+++ b/charts/copia/tests/cnpg_cluster_test.yaml
@@ -1,0 +1,191 @@
+suite: Test CloudNativePG Cluster
+templates:
+  - cnpg-cluster.yaml
+tests:
+  - it: renders nothing when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: fails when enabled without the CRD
+    set:
+      cloudnativePG.enabled: true
+      copia.config.database.PASSWD: s3cret
+    asserts:
+      - failedTemplate:
+          errorPattern: "CloudNativePG CRDs"
+  - it: fails when enabled without a database password
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "copia.config.database.PASSWD"
+  - it: renders owner secret and Cluster when enabled
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.NAME: copia
+      copia.config.database.USER: copia
+      copia.config.database.PASSWD: s3cret
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          any: true
+      - containsDocument:
+          apiVersion: postgresql.cnpg.io/v1
+          kind: Cluster
+          any: true
+  - it: Cluster uses bootstrap owner and storage from values
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      cloudnativePG.instances: 3
+      cloudnativePG.storage.size: 50Gi
+      cloudnativePG.storage.storageClass: gp3
+      copia.config.database.NAME: copia
+      copia.config.database.USER: copia
+      copia.config.database.PASSWD: s3cret
+    documentSelector:
+      path: kind
+      value: Cluster
+    asserts:
+      - equal:
+          path: metadata.name
+          value: copia-pg
+      - equal:
+          path: spec.instances
+          value: 3
+      - equal:
+          path: spec.storage.size
+          value: 50Gi
+      - equal:
+          path: spec.storage.storageClass
+          value: gp3
+      - equal:
+          path: spec.bootstrap.initdb.database
+          value: copia
+      - equal:
+          path: spec.bootstrap.initdb.owner
+          value: copia
+      - equal:
+          path: spec.bootstrap.initdb.secret.name
+          value: copia-pg-app
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+  - it: owner secret is basic-auth with username and password
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.USER: copia
+      copia.config.database.PASSWD: s3cret
+    documentSelector:
+      path: kind
+      value: Secret
+    asserts:
+      - equal:
+          path: metadata.name
+          value: copia-pg-app
+      - equal:
+          path: type
+          value: kubernetes.io/basic-auth
+      - equal:
+          path: stringData.username
+          value: copia
+      - equal:
+          path: stringData.password
+          value: s3cret
+  - it: extraSpec merges into the Cluster spec
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      copia.config.database.PASSWD: s3cret
+      cloudnativePG.extraSpec:
+        postgresql:
+          parameters:
+            max_connections: "200"
+    documentSelector:
+      path: kind
+      value: Cluster
+    asserts:
+      - equal:
+          path: spec.postgresql.parameters.max_connections
+          value: "200"
+  - it: creates conversion-manager Database and role when CM is enabled
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.PASSWD: s3cret
+      conversion_manager_service.enabled: true
+      conversion_manager_service.configmap.DB_NAME: conversion_manager
+      conversion_manager_service.configmap.DB_USER: conversion_manager
+      conversion_manager_service.secret.DB_PASSWORD: cm-secret
+    asserts:
+      - hasDocuments:
+          count: 4
+      - containsDocument:
+          apiVersion: postgresql.cnpg.io/v1
+          kind: Database
+          any: true
+  - it: conversion-manager Database targets the Cluster
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.PASSWD: s3cret
+      conversion_manager_service.enabled: true
+      conversion_manager_service.configmap.DB_NAME: conversion_manager
+      conversion_manager_service.configmap.DB_USER: conversion_manager
+      conversion_manager_service.secret.DB_PASSWORD: cm-secret
+    documentSelector:
+      path: kind
+      value: Database
+    asserts:
+      - equal:
+          path: spec.name
+          value: conversion_manager
+      - equal:
+          path: spec.owner
+          value: conversion_manager
+      - equal:
+          path: spec.cluster.name
+          value: copia-pg
+  - it: remaps reserved conversion-manager DB_USER postgres
+    capabilities:
+      apiVersions:
+        - postgresql.cnpg.io/v1
+    set:
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.PASSWD: s3cret
+      conversion_manager_service.enabled: true
+      conversion_manager_service.configmap.DB_USER: postgres
+      conversion_manager_service.secret.DB_PASSWORD: cm-secret
+    documentSelector:
+      path: kind
+      value: Database
+    asserts:
+      - equal:
+          path: spec.owner
+          value: conversion_manager

--- a/charts/copia/tests/conversion_manager_configmap_test.yaml
+++ b/charts/copia/tests/conversion_manager_configmap_test.yaml
@@ -50,12 +50,11 @@ tests:
       - equal:
           path: data.ENABLE_HTTPS
           value: "false"
-  - it: CloudNativePG overrides DB_HOST and remaps reserved DB_USER
+  - it: CloudNativePG sets DB_HOST from the Cluster and remaps reserved DB_USER
     set:
       conversion_manager_service.enabled: true
       cloudnativePG.enabled: true
       cloudnativePG.clusterName: copia-pg
-      conversion_manager_service.configmap.DB_HOST: postgres.example.com:5432
       conversion_manager_service.configmap.DB_USER: postgres
       conversion_manager_service.configmap.DB_NAME: conversion_manager
     asserts:
@@ -68,3 +67,11 @@ tests:
       - equal:
           path: data.DB_NAME
           value: "conversion_manager"
+  - it: fails when CloudNativePG is enabled with an external DB_HOST
+    set:
+      conversion_manager_service.enabled: true
+      cloudnativePG.enabled: true
+      conversion_manager_service.configmap.DB_HOST: postgres.example.com:5432
+    asserts:
+      - failedTemplate:
+          errorPattern: "omit conversion_manager_service.configmap.DB_HOST"

--- a/charts/copia/tests/conversion_manager_configmap_test.yaml
+++ b/charts/copia/tests/conversion_manager_configmap_test.yaml
@@ -50,3 +50,21 @@ tests:
       - equal:
           path: data.ENABLE_HTTPS
           value: "false"
+  - it: CloudNativePG overrides DB_HOST and remaps reserved DB_USER
+    set:
+      conversion_manager_service.enabled: true
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      conversion_manager_service.configmap.DB_HOST: postgres.example.com:5432
+      conversion_manager_service.configmap.DB_USER: postgres
+      conversion_manager_service.configmap.DB_NAME: conversion_manager
+    asserts:
+      - equal:
+          path: data.DB_HOST
+          value: "copia-pg-rw:5432"
+      - equal:
+          path: data.DB_USER
+          value: "conversion_manager"
+      - equal:
+          path: data.DB_NAME
+          value: "conversion_manager"

--- a/charts/copia/tests/conversion_manager_deployment_test.yaml
+++ b/charts/copia/tests/conversion_manager_deployment_test.yaml
@@ -155,4 +155,29 @@ tests:
           content:
             secretRef:
               name: conversion-manager-secrets
+  - it: waits for CloudNativePG before starting
+    set:
+      conversion_manager_service.enabled: true
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.PASSWD: s3cret
+      conversion_manager_service.configmap.DB_NAME: conversion_manager
+      conversion_manager_service.configmap.DB_USER: conversion_manager
+      conversion_manager_service.secret.DB_PASSWORD: cm-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-postgres
+      - equal:
+          path: spec.template.spec.initContainers[0].env[0].value
+          value: copia-pg-rw
+      - equal:
+          path: spec.template.spec.initContainers[0].env[2].value
+          value: conversion_manager
+      - equal:
+          path: spec.template.spec.initContainers[0].env[4].value
+          value: conversion_manager
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: pg_isready
 

--- a/charts/copia/tests/copia_deployment_test.yaml
+++ b/charts/copia/tests/copia_deployment_test.yaml
@@ -73,10 +73,27 @@ tests:
           value: localhost
       - equal:
           path: spec.template.spec.initContainers[0].env[1].value
-          value: postgres
+          value: "5432"
       - equal:
           path: spec.template.spec.initContainers[0].env[2].value
-          value: password
+          value: postgres
       - equal:
           path: spec.template.spec.initContainers[0].env[3].value
+          value: password
+      - equal:
+          path: spec.template.spec.initContainers[0].env[4].value
           value: copia
+  - it: waits for CloudNativePG read-write service
+    set:
+      cloudnativePG.enabled: true
+      copia.config.database.HOST: ignored.example.com:5432
+      copia.config.database.USER: copia
+      copia.config.database.NAME: copia
+      copia.config.database.PASSWD: s3cret
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].env[0].value
+          value: RELEASE-NAME-copia-pg-rw
+      - equal:
+          path: spec.template.spec.initContainers[0].env[1].value
+          value: "5432"

--- a/charts/copia/tests/copia_deployment_test.yaml
+++ b/charts/copia/tests/copia_deployment_test.yaml
@@ -86,7 +86,6 @@ tests:
   - it: waits for CloudNativePG read-write service
     set:
       cloudnativePG.enabled: true
-      copia.config.database.HOST: ignored.example.com:5432
       copia.config.database.USER: copia
       copia.config.database.NAME: copia
       copia.config.database.PASSWD: s3cret

--- a/charts/copia/tests/copia_deployment_test.yaml
+++ b/charts/copia/tests/copia_deployment_test.yaml
@@ -65,9 +65,12 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: copia
-      - matchRegex:
+      - equal:
           path: spec.template.spec.initContainers[0].image
-          pattern: postgres:latest
+          value: postgres:16-alpine
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: pg_isready
       - equal:
           path: spec.template.spec.initContainers[0].env[0].value
           value: localhost
@@ -96,3 +99,6 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].env[1].value
           value: "5432"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: waiting for postgres

--- a/charts/copia/tests/copia_secret_test.yaml
+++ b/charts/copia/tests/copia_secret_test.yaml
@@ -254,3 +254,17 @@ tests:
               [server]
               HTTP_PORT = 4001
               LFS_JWT_SECRET = ###LFS_JWT_SECRET###
+  - it: CloudNativePG overrides database HOST in app.ini
+    set:
+      chartGeneratedSecrets.enabled: false
+      cloudnativePG.enabled: true
+      cloudnativePG.clusterName: copia-pg
+      copia.config.database.HOST: postgres.example.com:5432
+      copia.config.database.DB_TYPE: postgres
+      copia.config.database.NAME: copia
+      copia.config.database.USER: copia
+      copia.config.database.PASSWD: s3cret
+    asserts:
+      - matchRegex:
+          path: stringData["app.ini"]
+          pattern: HOST = copia-pg-rw:5432

--- a/charts/copia/tests/copia_secret_test.yaml
+++ b/charts/copia/tests/copia_secret_test.yaml
@@ -254,12 +254,11 @@ tests:
               [server]
               HTTP_PORT = 4001
               LFS_JWT_SECRET = ###LFS_JWT_SECRET###
-  - it: CloudNativePG overrides database HOST in app.ini
+  - it: CloudNativePG sets database HOST in app.ini
     set:
       chartGeneratedSecrets.enabled: false
       cloudnativePG.enabled: true
       cloudnativePG.clusterName: copia-pg
-      copia.config.database.HOST: postgres.example.com:5432
       copia.config.database.DB_TYPE: postgres
       copia.config.database.NAME: copia
       copia.config.database.USER: copia
@@ -268,3 +267,11 @@ tests:
       - matchRegex:
           path: stringData["app.ini"]
           pattern: HOST = copia-pg-rw:5432
+  - it: fails when CloudNativePG is enabled with an external database HOST
+    set:
+      cloudnativePG.enabled: true
+      copia.config.database.HOST: postgres.example.com:5432
+      copia.config.database.PASSWD: s3cret
+    asserts:
+      - failedTemplate:
+          errorPattern: "omit copia.config.database.HOST"

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -446,6 +446,62 @@
       "type": "array",
       "description": "Repo auth secrets."
     },
+    "cloudnativePG": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional in-cluster Postgres via a CloudNativePG Cluster CR. The operator/CRDs must already be installed.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "requireCRD": {
+          "type": "boolean",
+          "description": "When true, helm install fails unless postgresql.cnpg.io/v1 is present."
+        },
+        "keepOnDelete": {
+          "type": "boolean",
+          "description": "Annotate CNPG resources with helm.sh/resource-policy keep."
+        },
+        "clusterName": {
+          "type": "string"
+        },
+        "instances": {
+          "type": "number"
+        },
+        "imageName": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "type": "array"
+        },
+        "storage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "extraSpec": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Merged into the Cluster spec for backups, monitoring, and other operator settings."
+        }
+      }
+    },
+
     "resources": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -252,3 +252,28 @@ conversion_manager_service:
     ADMIN_KEY: testAdminKey
     COPIA_USER_KEY: testCopiaUserKey
     COPIA_TEAM_KEY: testCopiaTeamKey
+
+# Optional in-cluster Postgres via a CloudNativePG Cluster CR. The operator and
+# CRDs must already be installed in the cluster; this chart does not deploy them.
+# When enabled, Copia and conversion-manager are pointed at <clusterName>-rw:5432
+# and HOST / DB_HOST values are ignored. See docs/distr/cloudnativepg.md.
+cloudnativePG:
+  enabled: false
+  # Fail helm install/upgrade unless postgresql.cnpg.io/v1 is registered.
+  requireCRD: true
+  # Keep Cluster (and its PVCs) if the chart is uninstalled or this option is
+  # turned off. Set false only for disposable environments.
+  keepOnDelete: true
+  # Default: <release-fullname>-pg
+  clusterName: ""
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  storage:
+    size: 20Gi
+    storageClass: ""
+  resources: {}
+  # Merged into the Cluster spec (postgresql.parameters, backup, monitoring, ...).
+  extraSpec: {}
+

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -261,9 +261,9 @@ cloudnativePG:
   enabled: false
   # Fail helm install/upgrade unless postgresql.cnpg.io/v1 is registered.
   requireCRD: true
-  # Keep Cluster (and its PVCs) if the chart is uninstalled or this option is
-  # turned off. Set false only for disposable environments.
-  keepOnDelete: true
+  # When true, helm uninstall leaves the Cluster (and its PVCs). Leave false so
+  # undeploy/redeploy can bootstrap a new volume; set true only to keep data.
+  keepOnDelete: false
   # Default: <release-fullname>-pg
   clusterName: ""
   instances: 1
@@ -272,7 +272,7 @@ cloudnativePG:
   imagePullSecrets: []
   storage:
     size: 20Gi
-    storageClass: ""
+    storageClass: single
   resources: {}
   # Merged into the Cluster spec (postgresql.parameters, backup, monitoring, ...).
   extraSpec: {}

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -255,8 +255,8 @@ conversion_manager_service:
 
 # Optional in-cluster Postgres via a CloudNativePG Cluster CR. The operator and
 # CRDs must already be installed in the cluster; this chart does not deploy them.
-# When enabled, Copia and conversion-manager are pointed at <clusterName>-rw:5432
-# and HOST / DB_HOST values are ignored. See docs/distr/cloudnativepg.md.
+# When enabled, omit HOST / DB_HOST (or leave the localhost chart default);
+# the apps use <clusterName>-rw:5432. See docs/distr/cloudnativepg.md.
 cloudnativePG:
   enabled: false
   # Fail helm install/upgrade unless postgresql.cnpg.io/v1 is registered.

--- a/docs/distr/cloudnativepg.md
+++ b/docs/distr/cloudnativepg.md
@@ -29,9 +29,10 @@ checks also look for `clusters.postgresql.cnpg.io`.
 
 ## Customer values
 
-Flip `cloudnativePG.enabled` to `true`. You can leave `HOST` and `DB_HOST` in
-place; the chart ignores them and points both apps at the Cluster read-write
-Service (`<clusterName>-rw:5432`). Keep `NAME`, `USER`, and `PASSWD`.
+Flip `cloudnativePG.enabled` to `true` and **remove** `copia.config.database.HOST` and
+`conversion_manager_service.configmap.DB_HOST`. The chart points both apps at the
+Cluster read-write Service (`<clusterName>-rw:5432`). Leaving an external host in
+place fails the install. Keep `NAME`, `USER`, and `PASSWD`.
 
 ```yaml
 cloudnativePG:

--- a/docs/distr/cloudnativepg.md
+++ b/docs/distr/cloudnativepg.md
@@ -1,0 +1,130 @@
+# CloudNativePG Config
+
+This guide covers running Copia's Postgres **in-cluster** with
+[CloudNativePG](https://cloudnative-pg.io/). The Copia Helm chart can create a
+`Cluster` (and an extra `Database` for conversion-manager). It does **not**
+install the CloudNativePG operator.
+
+Use this when you do not already have an external Postgres (RDS, Cloud SQL, or
+similar). If you do, leave `cloudnativePG.enabled` false and set `HOST` /
+`DB_HOST` as in the default customer values.
+
+## Prerequisites
+
+- CloudNativePG operator **1.22 or newer** already installed in the cluster
+  (the `postgresql.cnpg.io/v1` CRDs must be present)
+- A StorageClass that can provision ReadWriteOnce volumes for Postgres
+- Distr secrets `CopiaDbPassword` and `ConversionManagerDbPassword` (if you use
+  conversion-manager)
+
+Confirm the CRDs:
+
+```bash
+kubectl get crd clusters.postgresql.cnpg.io databases.postgresql.cnpg.io
+```
+
+The chart fails `helm install`/`upgrade` with a clear error if
+`cloudnativePG.enabled` is true and `postgresql.cnpg.io/v1` is missing. Preflight
+checks also look for `clusters.postgresql.cnpg.io`.
+
+## Customer values
+
+Flip `cloudnativePG.enabled` to `true`. You can leave `HOST` and `DB_HOST` in
+place; the chart ignores them and points both apps at the Cluster read-write
+Service (`<clusterName>-rw:5432`). Keep `NAME`, `USER`, and `PASSWD`.
+
+```yaml
+cloudnativePG:
+  enabled: true
+  instances: 1
+  storage:
+    size: 50Gi
+    storageClass: gp3
+copia:
+  config:
+    database:
+      NAME: copia
+      USER: copia
+      PASSWD: "{{ .Secrets.CopiaDbPassword }}"
+      SSL_MODE: require
+conversion_manager_service:
+  configmap:
+    DB_NAME: conversion_manager
+    DB_USER: conversion_manager
+  secret:
+    DB_PASSWORD: "{{ .Secrets.ConversionManagerDbPassword }}"
+```
+
+`USER` must not be `postgres` or `streaming_replica` (CloudNativePG reserves
+those). `copia` is the usual owner name.
+
+### Optional knobs
+
+| Value | Default | Purpose |
+|---|---|---|
+| `cloudnativePG.clusterName` | `<fullname>-pg` | Cluster object and Service prefix |
+| `cloudnativePG.instances` | `1` | Postgres pods. Use `3` for HA |
+| `cloudnativePG.imageName` | `ghcr.io/cloudnative-pg/postgresql:16` | Operand image (mirror this if air-gapped) |
+| `cloudnativePG.storage.size` | `20Gi` (chart) / `50Gi` (customer example) | Data volume |
+| `cloudnativePG.storage.storageClass` | cluster default | Must support RWO |
+| `cloudnativePG.keepOnDelete` | `true` | Helm will not delete the Cluster on uninstall |
+| `cloudnativePG.extraSpec` | `{}` | Merged into the Cluster spec |
+
+### `extraSpec` examples
+
+HA anti-affinity, Postgres parameters, or backups go in `extraSpec` and are
+merged into the Cluster spec:
+
+```yaml
+cloudnativePG:
+  enabled: true
+  instances: 3
+  extraSpec:
+    postgresql:
+      parameters:
+        max_connections: "200"
+        shared_buffers: "256MB"
+```
+
+See the [CloudNativePG Cluster spec](https://cloudnative-pg.io/documentation/current/)
+for the full field list.
+
+## What the chart creates
+
+When `cloudnativePG.enabled` is true:
+
+1. A `kubernetes.io/basic-auth` Secret for the Copia owner (`username` /
+   `password` from `copia.config.database`)
+2. A CloudNativePG `Cluster` bootstrapped with that owner and database
+3. If conversion-manager is enabled: a second auth Secret, a managed role, and a
+   `Database` CR for `conversion_manager`
+
+The read-write Service is `<clusterName>-rw` on port 5432. Copia waits for
+Postgres with an init container before the app starts.
+
+## Conversion-manager
+
+The default chart `DB_USER` is `postgres`, which CloudNativePG does not allow as
+a managed role. The chart remaps that to `conversion_manager`. Set `DB_USER` to
+`conversion_manager` (as in the customer example) to make the values match what
+is created.
+
+Requires CloudNativePG 1.22+ for the `Database` CRD.
+
+## Uninstall and disable
+
+`keepOnDelete` defaults to true, so `helm uninstall` or setting `enabled: false`
+does not delete the Cluster or its PVCs. To tear the database down, delete the
+Cluster yourself after you have backups:
+
+```bash
+kubectl -n copia delete cluster.postgresql.cnpg.io <clusterName>
+```
+
+## Troubleshooting
+
+- **Helm: CRDs were not found** — install the operator, then retry deploy
+- **Copia crash-loop / init container waiting** — `kubectl -n copia get cluster`
+  and describe the Cluster; storage and image pull are the usual causes
+- **conversion-manager cannot log in** — confirm `DB_USER` is not `postgres`, and
+  that `ConversionManagerDbPassword` matches the Secret the chart created

--- a/docs/distr/cloudnativepg.md
+++ b/docs/distr/cloudnativepg.md
@@ -58,7 +58,7 @@ cloudnativePG:
   instances: 1
   storage:
     size: 50Gi
-    storageClass: gp3
+    storageClass: single
 copia:
   config:
     database:
@@ -85,8 +85,8 @@ those). `copia` is the usual owner name.
 | `cloudnativePG.instances` | `1` | Postgres pods. Use `3` for HA |
 | `cloudnativePG.imageName` | `ghcr.io/cloudnative-pg/postgresql:16` | Operand image (mirror this if air-gapped) |
 | `cloudnativePG.storage.size` | `20Gi` (chart) / `50Gi` (customer example) | Data volume |
-| `cloudnativePG.storage.storageClass` | cluster default | Must support RWO |
-| `cloudnativePG.keepOnDelete` | `true` | Helm will not delete the Cluster on uninstall |
+| `cloudnativePG.storage.storageClass` | `single` | Must support RWO |
+| `cloudnativePG.keepOnDelete` | `false` | When true, Helm will not delete the Cluster on uninstall |
 | `cloudnativePG.extraSpec` | `{}` | Merged into the Cluster spec |
 
 ### `extraSpec` examples
@@ -118,8 +118,9 @@ When `cloudnativePG.enabled` is true:
 3. If conversion-manager is enabled: a second auth Secret, a managed role, and a
    `Database` CR for `conversion_manager`
 
-The read-write Service is `<clusterName>-rw` on port 5432. Copia waits for
-Postgres with an init container before the app starts.
+The read-write Service is `<clusterName>-rw` on port 5432. Copia and
+conversion-manager wait in an init container (`pg_isready`, then `SELECT 1`)
+until that database exists, so they do not start during CNPG `initdb`.
 
 ## Conversion-manager
 
@@ -132,13 +133,21 @@ Requires CloudNativePG 1.22+ for the `Database` CRD.
 
 ## Uninstall and disable
 
-`keepOnDelete` defaults to true, so `helm uninstall` or setting `enabled: false`
-does not delete the Cluster or its PVCs. To tear the database down, delete the
-Cluster yourself after you have backups:
+By default `keepOnDelete` is false, so `helm uninstall` (Distr undeploy) deletes
+the Cluster. CloudNativePG then deletes the instance pods and PVCs. The next
+deploy creates a new Cluster and new PVCs and runs `initdb` again.
+
+If a previous install used `keepOnDelete: true`, undeploy leaves the Cluster CR
+behind. Redeploy will not create new PVCs: CloudNativePG refuses to `initdb`
+over an existing Cluster. Delete the leftover Cluster (this also removes its
+PVCs), then deploy again:
 
 ```bash
 kubectl -n copia delete cluster.postgresql.cnpg.io <clusterName>
+kubectl -n copia get pvc
 ```
+
+Set `keepOnDelete: true` only when you must keep the database across undeploy.
 
 ## Troubleshooting
 
@@ -148,5 +157,8 @@ kubectl -n copia delete cluster.postgresql.cnpg.io <clusterName>
   the operator on that blueprint.
 - **Copia crash-loop / init container waiting** — `kubectl -n copia get cluster`
   and describe the Cluster; storage and image pull are the usual causes
+- **PVC missing after undeploy/redeploy** — a leftover Cluster CR from
+  `keepOnDelete` blocks a new volume. Delete the Cluster, wait for PVCs to
+  disappear, then redeploy
 - **conversion-manager cannot log in** — confirm `DB_USER` is not `postgres`, and
   that `ConversionManagerDbPassword` matches the Secret the chart created

--- a/docs/distr/cloudnativepg.md
+++ b/docs/distr/cloudnativepg.md
@@ -17,7 +17,25 @@ similar). If you do, leave `cloudnativePG.enabled` false and set `HOST` /
 - Distr secrets `CopiaDbPassword` and `ConversionManagerDbPassword` (if you use
   conversion-manager)
 
-Confirm the CRDs:
+### Install the operator (infrastructure agent)
+
+The Copia chart does not install the operator. If the infrastructure agent
+provisioned the cluster with Windsor Core `oci://ghcr.io/windsorcli/core:v0.7.0`,
+set these on that application's Environment tab:
+
+```bash
+CORE_DATABASE__POSTGRES__ENABLED=true
+CORE_DATABASE__POSTGRES__DRIVER=cloudnativepg
+```
+
+That writes `database.postgres.enabled` and `database.postgres.driver` in Windsor
+`values.yaml`. The next reconcile installs the operator HelmRelease (`database` /
+`cloudnativepg` in Flux).
+
+Do **not** set `CORE_ADDONS__DATABASE__POSTGRES__*`. Those keys write
+`addons.database.postgres`, which Core `v0.7.0` ignores.
+
+Confirm the CRDs after reconcile:
 
 ```bash
 kubectl get crd clusters.postgresql.cnpg.io databases.postgresql.cnpg.io
@@ -124,7 +142,10 @@ kubectl -n copia delete cluster.postgresql.cnpg.io <clusterName>
 
 ## Troubleshooting
 
-- **Helm: CRDs were not found** — install the operator, then retry deploy
+- **Helm: CRDs were not found** — install the operator
+  (`CORE_DATABASE__POSTGRES__ENABLED=true` on the infrastructure application for
+  Core `v0.7.0`), then retry deploy. `CORE_ADDONS__DATABASE__*` does not enable
+  the operator on that blueprint.
 - **Copia crash-loop / init container waiting** — `kubectl -n copia get cluster`
   and describe the Cluster; storage and image pull are the usual causes
 - **conversion-manager cannot log in** — confirm `DB_USER` is not `postgres`, and

--- a/docs/distr/install.md
+++ b/docs/distr/install.md
@@ -26,6 +26,16 @@ Required environment fields include hostname, database connection settings, and 
 details. See the environment template on your deployment for the full list. Empty required
 fields keep **Deploy** disabled.
 
+### Database
+
+Copia needs PostgreSQL. Two supported layouts:
+
+- **External Postgres** (default customer values) — set `copia.config.database.HOST`
+  and conversion-manager `DB_HOST` to your server.
+- **In-cluster CloudNativePG** — install the CloudNativePG operator on the cluster
+  first, then set `cloudnativePG.enabled: true`. The chart creates a `Cluster` CR
+  and points the apps at it. See [CloudNativePG Config](./cloudnativepg.md).
+
 ## Install the Kubernetes agent
 
 Copy the connect command from your deployment page in Distr and run it against your cluster.

--- a/docs/distr/install.md
+++ b/docs/distr/install.md
@@ -32,10 +32,14 @@ Copia needs PostgreSQL. Two supported layouts:
 
 - **External Postgres** (default customer values) — set `copia.config.database.HOST`
   and conversion-manager `DB_HOST` to your server.
-- **In-cluster CloudNativePG** — install the CloudNativePG operator on the cluster
-  first, then set `cloudnativePG.enabled: true` and remove `HOST` / `DB_HOST`.
-  The chart creates a `Cluster` CR and points the apps at it. See
+- **In-cluster CloudNativePG** — on the **infrastructure** application, set
+  `CORE_DATABASE__POSTGRES__ENABLED=true` and
+  `CORE_DATABASE__POSTGRES__DRIVER=cloudnativepg` (Windsor Core `v0.7.0`). Wait
+  until `kubectl get crd clusters.postgresql.cnpg.io` succeeds, then set
+  `cloudnativePG.enabled: true` and remove `HOST` / `DB_HOST`. The chart creates
+  a `Cluster` CR and points the apps at it. See
   [CloudNativePG Config](./cloudnativepg.md).
+  Do not use `CORE_ADDONS__DATABASE__*` with Core `v0.7.0`.
 
 ## Install the Kubernetes agent
 

--- a/docs/distr/install.md
+++ b/docs/distr/install.md
@@ -33,8 +33,9 @@ Copia needs PostgreSQL. Two supported layouts:
 - **External Postgres** (default customer values) — set `copia.config.database.HOST`
   and conversion-manager `DB_HOST` to your server.
 - **In-cluster CloudNativePG** — install the CloudNativePG operator on the cluster
-  first, then set `cloudnativePG.enabled: true`. The chart creates a `Cluster` CR
-  and points the apps at it. See [CloudNativePG Config](./cloudnativepg.md).
+  first, then set `cloudnativePG.enabled: true` and remove `HOST` / `DB_HOST`.
+  The chart creates a `Cluster` CR and points the apps at it. See
+  [CloudNativePG Config](./cloudnativepg.md).
 
 ## Install the Kubernetes agent
 

--- a/script/render-check.sh
+++ b/script/render-check.sh
@@ -19,6 +19,8 @@ main() {
     --values charts/copia/distr/values.base.yaml \
     --values charts/copia/distr/values.customer.example.yaml \
     --set cloudnativePG.enabled=true \
+    --set copia.config.database.HOST= \
+    --set conversion_manager_service.configmap.DB_HOST= \
     >/dev/null
   log::success "Distr overlay with cloudnativePG.enabled renders cleanly"
 }

--- a/script/render-check.sh
+++ b/script/render-check.sh
@@ -13,6 +13,14 @@ main() {
     --values charts/copia/distr/values.customer.example.yaml \
     >/dev/null
   log::success "Distr base + per-target overlay renders cleanly"
+
+  log::exec_command helm template copia charts/copia \
+    --api-versions postgresql.cnpg.io/v1 \
+    --values charts/copia/distr/values.base.yaml \
+    --values charts/copia/distr/values.customer.example.yaml \
+    --set cloudnativePG.enabled=true \
+    >/dev/null
+  log::success "Distr overlay with cloudnativePG.enabled renders cleanly"
 }
 
 main "$@"


### PR DESCRIPTION
Assume the operator CRDs are already installed, fail install when they are missing, and document the Distr customer values for enabling the Cluster.

<!-- This is a guideline -->

## Description
<!-- Please provide a brief description of the changes being made -->

## Checklist
<!-- Please place an "x" between brackets to mark each relevant box -->

<!-- This Pull Request ... -->
- [ ] Links to Clickup
- [ ] Follows PR title convention (`<label>:ENG-XXXX <description>`)
- [ ] Introduces new tests on the code paths changed
- [ ] Has been manually verified
- [ ] Generates no new console or log warnings/errors (manual check)
- [ ] Documentation added/updated as applicable

## Testing Description
<!-- Please provide a brief description of the type of testing done as applicable -->

<!-- If relevant, please include before and after screenshots or videos of any UI/UX, data-contract, testing or other changes -->
### Before

### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional in-cluster PostgreSQL provisioning through CloudNativePG.
  * Added configurable instances, storage, resources, images, retention, and operator settings.
  * Added automatic database connection configuration for Copia and the conversion manager.
  * Added database readiness checks and validation for credentials, required CRDs, hosts, and reserved usernames.

* **Documentation**
  * Added CloudNativePG deployment, configuration, conversion-manager, uninstall, and troubleshooting guidance.
  * Updated installation guidance for supported database layouts and readiness requirements.

* **Tests**
  * Added coverage for rendering, configuration propagation, validation, and deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->