### PR TITLE
Add optional Crossplane RDS database provider to Copia chart

### DIFF
--- a/charts/copia/distr/values.customer.example.yaml
+++ b/charts/copia/distr/values.customer.example.yaml
@@ -28,13 +28,25 @@ cloudnativePG:
   storage:
     size: 50Gi
     storageClass: single
+# AWS RDS via Crossplane (mutually exclusive with cloudnativePG). Requires
+# Crossplane + PostgresInstance XRD/Composition. Omit HOST/PASSWD when enabled.
+# See docs/distr/crossplane.md.
+# database:
+#   provider: crossplane
+# crossplane:
+#   enabled: true
+#   parameters:
+#     region: us-east-2
+#     subnetIds: []
+#     vpcSecurityGroupIds: []
 copia:
   config:
     server:
       DOMAIN: copia.example.com
       ROOT_URL: https://copia.example.com/
     database:
-      # Required for an existing Postgres. Remove this key when using CloudNativePG.
+      # Required for an existing Postgres. Remove this key when using CloudNativePG
+      # or Crossplane.
       HOST: postgres.example.com:5432
       NAME: copia
       USER: copia

--- a/charts/copia/examples/crossplane/composition-postgres.yaml
+++ b/charts/copia/examples/crossplane/composition-postgres.yaml
@@ -1,0 +1,153 @@
+---
+# Staging / spike Composition (Crossplane v2 pipeline mode).
+# Remaps connection Secret keys to the nexus contract:
+# user, password, host, port, dbname.
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpostgresinstances.aws.copia.io
+  labels:
+    aws.copia.io/provider: aws
+spec:
+  compositeTypeRef:
+    apiVersion: aws.copia.io/v1alpha1
+    kind: XPostgresInstance
+  writeConnectionSecretsToNamespace: crossplane-system
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: subnetgroup
+            base:
+              apiVersion: rds.aws.upbound.io/v1beta1
+              kind: SubnetGroup
+              spec:
+                forProvider:
+                  description: Crossplane-managed DB subnet group for Copia Postgres
+                  tags:
+                    managed-by: crossplane
+                    project: copia
+                providerConfigRef:
+                  name: default
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.region
+                toFieldPath: spec.forProvider.region
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.subnetIds
+                toFieldPath: spec.forProvider.subnetIds
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.providerConfigName
+                toFieldPath: spec.providerConfigRef.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.name
+                toFieldPath: metadata.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-subnets"
+          - name: instance
+            base:
+              apiVersion: rds.aws.upbound.io/v1beta1
+              kind: Instance
+              spec:
+                forProvider:
+                  engine: postgres
+                  engineVersion: "15"
+                  instanceClass: db.t4g.micro
+                  allocatedStorage: 20
+                  dbName: copia
+                  username: copia
+                  autoGeneratePassword: true
+                  publiclyAccessible: false
+                  skipFinalSnapshot: true
+                  passwordSecretRef:
+                    namespace: crossplane-system
+                    key: password
+                  tags:
+                    managed-by: crossplane
+                    project: copia
+                providerConfigRef:
+                  name: default
+                writeConnectionSecretToRef:
+                  namespace: crossplane-system
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.region
+                toFieldPath: spec.forProvider.region
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.engineVersion
+                toFieldPath: spec.forProvider.engineVersion
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.instanceClass
+                toFieldPath: spec.forProvider.instanceClass
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.allocatedStorage
+                toFieldPath: spec.forProvider.allocatedStorage
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.dbName
+                toFieldPath: spec.forProvider.dbName
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.username
+                toFieldPath: spec.forProvider.username
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.vpcSecurityGroupIds
+                toFieldPath: spec.forProvider.vpcSecurityGroupIds
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.skipFinalSnapshot
+                toFieldPath: spec.forProvider.skipFinalSnapshot
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.providerConfigName
+                toFieldPath: spec.providerConfigRef.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.name
+                toFieldPath: metadata.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.identifier
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.dbSubnetGroupName
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-subnets"
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.uid
+                toFieldPath: spec.forProvider.passwordSecretRef.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-pgpass"
+              - type: FromCompositeFieldPath
+                fromFieldPath: metadata.uid
+                toFieldPath: spec.writeConnectionSecretToRef.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-rds"
+            connectionDetails:
+              - name: user
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: username
+              - name: password
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: password
+              - name: host
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: host
+              - name: port
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: port
+              - name: dbname
+                type: FromFieldPath
+                fromFieldPath: spec.forProvider.dbName

--- a/charts/copia/examples/crossplane/function-patch-and-transform.yaml
+++ b/charts/copia/examples/crossplane/function-patch-and-transform.yaml
@@ -1,0 +1,8 @@
+---
+# Required by Crossplane v2 Compositions (legacy spec.resources was removed).
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-patch-and-transform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2

--- a/charts/copia/examples/crossplane/kustomization.yaml
+++ b/charts/copia/examples/crossplane/kustomization.yaml
@@ -1,0 +1,9 @@
+# Apply XRD + Composition before `helm install` with database.provider=crossplane.
+# Requires Crossplane + provider-aws-rds + ProviderConfig (IRSA) already healthy.
+# Crossplane v2 needs function-patch-and-transform (included here).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - function-patch-and-transform.yaml
+  - xrd-postgres.yaml
+  - composition-postgres.yaml

--- a/charts/copia/examples/crossplane/xrd-postgres.yaml
+++ b/charts/copia/examples/crossplane/xrd-postgres.yaml
@@ -1,0 +1,76 @@
+---
+# Staging / spike XRD. Apply before helm install with database.provider=crossplane.
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresinstances.aws.copia.io
+spec:
+  group: aws.copia.io
+  names:
+    kind: XPostgresInstance
+    plural: xpostgresinstances
+  claimNames:
+    kind: PostgresInstance
+    plural: postgresinstances
+  connectionSecretKeys:
+    - user
+    - password
+    - host
+    - port
+    - dbname
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    region:
+                      type: string
+                    engineVersion:
+                      type: string
+                      default: "15"
+                    instanceClass:
+                      type: string
+                      default: db.t4g.micro
+                    allocatedStorage:
+                      type: integer
+                      default: 20
+                    dbName:
+                      type: string
+                      default: copia
+                    username:
+                      type: string
+                      default: copia
+                    subnetIds:
+                      type: array
+                      items:
+                        type: string
+                      minItems: 2
+                    vpcSecurityGroupIds:
+                      type: array
+                      items:
+                        type: string
+                      minItems: 1
+                    providerConfigName:
+                      type: string
+                      default: default
+                    skipFinalSnapshot:
+                      type: boolean
+                      default: true
+                  required:
+                    - region
+                    - subnetIds
+                    - vpcSecurityGroupIds
+              required:
+                - parameters
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/charts/copia/templates/_helpers.tpl
+++ b/charts/copia/templates/_helpers.tpl
@@ -160,25 +160,25 @@ CloudNativePG Cluster object name. DNS label, kept short enough for -rw/-r suffi
 Postgres application owner. Defaults to copia. Reserved CNPG roles are rejected.
 */}}
 {{- define "copia.database.user" -}}
-{{- $user := "copia" }}
-{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.USER }}
-{{- $user = .Values.copia.config.database.USER }}
-{{- end }}
-{{- if and (eq "true" (include "copia.cnpg.enabled" .)) (or (eq $user "postgres") (eq $user "streaming_replica")) }}
-{{- fail "cloudnativePG.enabled cannot use database USER postgres or streaming_replica (reserved by CloudNativePG)." }}
-{{- end }}
-{{- $user }}
+{{- $user := "copia" -}}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.USER -}}
+{{- $user = .Values.copia.config.database.USER -}}
+{{- end -}}
+{{- if and (eq "true" (include "copia.cnpg.enabled" .)) (or (eq $user "postgres") (eq $user "streaming_replica")) -}}
+{{- fail "cloudnativePG.enabled cannot use database USER postgres or streaming_replica (reserved by CloudNativePG)." -}}
+{{- end -}}
+{{- $user -}}
 {{- end -}}
 
 {{/*
 Postgres database name for Copia. Defaults to copia.
 */}}
 {{- define "copia.database.name" -}}
-{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.NAME }}
-{{- .Values.copia.config.database.NAME }}
-{{- else }}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.NAME -}}
+{{- .Values.copia.config.database.NAME -}}
+{{- else -}}
 copia
-{{- end }}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -268,4 +268,50 @@ conversion-manager role name. Remaps reserved postgres/streaming_replica names.
 {{- else }}
 conversion_manager
 {{- end }}
+{{- end -}}
+
+{{/*
+Return "true" when the chart should emit a Crossplane Postgres Claim and read
+DB credentials from a connection Secret (nexus keys: user/password/host/port/dbname).
+
+Enable with crossplane.enabled=true or database.provider=crossplane (Step 10).
+Mutually exclusive with cloudnativePG.enabled.
+*/}}
+{{- define "copia.crossplane.enabled" -}}
+{{- $fromBlock := and .Values.crossplane .Values.crossplane.enabled -}}
+{{- $fromProvider := and .Values.database (eq (.Values.database.provider | default "") "crossplane") -}}
+{{- if or $fromBlock $fromProvider -}}
+{{- if eq "true" (include "copia.cnpg.enabled" .) -}}
+{{- fail "crossplane and cloudnativePG cannot both be enabled; pick one database path." -}}
+{{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "copia.crossplane.claimName" -}}
+{{- if and .Values.crossplane .Values.crossplane.claimName }}
+{{- .Values.crossplane.claimName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-pg" (include "app.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end -}}
+
+{{- define "copia.crossplane.connectionSecretName" -}}
+{{- if and .Values.crossplane .Values.crossplane.connectionSecretName }}
+{{- .Values.crossplane.connectionSecretName }}
+{{- else }}
+copia-db-app
+{{- end }}
+{{- end -}}
+
+{{- define "copia.crossplane.validateHosts" -}}
+{{- if eq "true" (include "copia.crossplane.enabled" .) -}}
+{{- $host := "" -}}
+{{- if and .Values.copia .Values.copia.config .Values.copia.config.database .Values.copia.config.database.HOST -}}
+{{- $host = .Values.copia.config.database.HOST | toString -}}
+{{- end -}}
+{{- if and $host (ne (include "copia.cnpg.isPlaceholderHost" $host) "true") -}}
+{{- fail "crossplane database provider is enabled; omit copia.config.database.HOST (and PASSWD) — credentials come from the connection Secret." -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/copia/templates/_wait_postgres.tpl
+++ b/charts/copia/templates/_wait_postgres.tpl
@@ -54,3 +54,76 @@ initdb.
     - name: PGSSLMODE
       value: {{ .sslMode | default "prefer" | quote }}
 {{- end -}}
+
+{{/*
+Init container that waits on Postgres using credentials from a connection Secret
+(Crossplane writeConnectionSecretToRef / nexus-style copia-db-app).
+
+Secret keys (preferred): host, port, user, password, dbname
+Also accepts Crossplane defaults: endpoint/username (and optional attribute.*).
+Kubelet blocks start until required keys exist (optional: false).
+*/}}
+{{- define "copia.waitPostgres.fromSecret.initContainer" -}}
+- name: {{ .name }}
+  image: postgres:16-alpine
+  imagePullPolicy: IfNotPresent
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+      SECRET=/etc/db-secret
+      read_secret() {
+        for key in "$@"; do
+          if [ -e "${SECRET}/${key}" ]; then
+            tr -d '\n' < "${SECRET}/${key}"
+            return 0
+          fi
+        done
+        return 1
+      }
+      host="$(read_secret host endpoint address || true)"
+      if [ -z "${host}" ]; then
+        echo "missing host/endpoint in ${SECRET}; keys:" >&2
+        ls -1 "${SECRET}" >&2 || true
+        exit 1
+      fi
+      host="${host%%:*}"
+      port="$(read_secret port || echo 5432)"
+      user="$(read_secret user username || true)"
+      pass="$(read_secret password attribute.password || true)"
+      db="$(read_secret dbname database || echo {{ (.database | default "copia") | quote }})"
+      export PGHOST="$host" PGPORT="$port" PGUSER="$user" PGPASSWORD="$pass" PGDATABASE="$db"
+      export PGSSLMODE={{ (.sslMode | default "require") | quote }}
+      echo "waiting for postgres ${PGHOST}:${PGPORT}/${PGDATABASE}"
+      max_attempts=180
+      attempt=0
+      until pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -t 3; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "postgres readiness timeout"
+          exit 1
+        fi
+        sleep 2
+      done
+      attempt=0
+      until psql -tAc "SELECT 1" | grep -q 1; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$max_attempts" ]; then
+          echo "postgres login timeout"
+          exit 1
+        fi
+        sleep 2
+      done
+      echo "postgres is ready"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  volumeMounts:
+    - name: {{ .volumeName | default "db-secret" }}
+      mountPath: /etc/db-secret
+      readOnly: true
+{{- end -}}

--- a/charts/copia/templates/conversion-manager-secrets-hook.yaml
+++ b/charts/copia/templates/conversion-manager-secrets-hook.yaml
@@ -1,3 +1,6 @@
+{{- /* Always create conversion-manager-secrets when chartGeneratedSecrets is on:
+     copia Deployment mounts it for MANAGEMENT_TOKEN placeholder substitution even
+     if conversion_manager_service.enabled is false. */ -}}
 {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
 ---
 apiVersion: v1

--- a/charts/copia/templates/copia-deployment.yaml
+++ b/charts/copia/templates/copia-deployment.yaml
@@ -51,10 +51,12 @@ spec:
       {{- $secretsOn := and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
       {{- $autoGen := and (hasKey .Values.copia "config") $secretsOn }}
       {{- $cnpgOn := eq "true" (include "copia.cnpg.enabled" .) }}
-      {{- $waitPg := and .Values.copia.config (or .Values.deployment.preflight $cnpgOn) }}
-      {{- if or $waitPg $autoGen }}
+      {{- $xpOn := eq "true" (include "copia.crossplane.enabled" .) }}
+      {{- $renderIni := or $autoGen $xpOn }}
+      {{- $waitPg := and .Values.copia.config (or .Values.deployment.preflight $cnpgOn $xpOn) }}
+      {{- if or $waitPg $renderIni }}
       initContainers:
-        {{- if $waitPg }}
+        {{- if and $waitPg (not $xpOn) }}
         {{- $sslMode := "prefer" }}
         {{- if and .Values.copia.config.database .Values.copia.config.database.SSL_MODE }}
         {{- $sslMode = .Values.copia.config.database.SSL_MODE }}
@@ -69,7 +71,19 @@ spec:
           "sslMode" $sslMode
         ) | nindent 8 }}
         {{- end }}
-        {{- if $autoGen }}
+        {{- if $xpOn }}
+        {{- $sslMode := "require" }}
+        {{- if and .Values.copia.config.database .Values.copia.config.database.SSL_MODE }}
+        {{- $sslMode = .Values.copia.config.database.SSL_MODE }}
+        {{- end }}
+        {{- include "copia.waitPostgres.fromSecret.initContainer" (dict
+          "name" (printf "%s-wait-db" .Chart.Name)
+          "database" (include "copia.database.name" .)
+          "sslMode" $sslMode
+          "volumeName" "db-secret"
+        ) | nindent 8 }}
+        {{- end }}
+        {{- if $renderIni }}
         - name: render-app-ini
           image: alpine:3.22
           command: ["/bin/sh", "-c"]
@@ -77,7 +91,27 @@ spec:
             - |
               set -eu
               cp /tmp/template/app.ini /tmp/final/app.ini
-              for dir in /tmp/secrets /tmp/cm-secrets; do
+              if [ -d /tmp/db-secret ]; then
+                mkdir -p /tmp/db-mapped
+                read_secret() {
+                  for key in "$@"; do
+                    if [ -e "/tmp/db-secret/${key}" ]; then
+                      tr -d '\n' < "/tmp/db-secret/${key}"
+                      return 0
+                    fi
+                  done
+                  return 1
+                }
+                host="$(read_secret host endpoint address || true)"
+                host="${host%%:*}"
+                port="$(read_secret port || echo 5432)"
+                user="$(read_secret user username || true)"
+                pass="$(read_secret password attribute.password || true)"
+                printf '%s:%s' "$host" "$port" > /tmp/db-mapped/XP_DB_HOST
+                printf '%s' "$user" > /tmp/db-mapped/XP_DB_USER
+                printf '%s' "$pass" > /tmp/db-mapped/XP_DB_PASSWD
+              fi
+              for dir in /tmp/secrets /tmp/cm-secrets /tmp/db-mapped; do
                 [ -d "$dir" ] || continue
                 for f in "$dir"/*; do
                   [ -e "$f" ] || continue
@@ -107,10 +141,17 @@ spec:
           volumeMounts:
             - name: app-ini-template
               mountPath: /tmp/template
+            {{- if $autoGen }}
             - name: gitea-secrets
               mountPath: /tmp/secrets
             - name: conversion-manager-secrets
               mountPath: /tmp/cm-secrets
+            {{- end }}
+            {{- if $xpOn }}
+            - name: db-secret
+              mountPath: /tmp/db-secret
+              readOnly: true
+            {{- end }}
             - name: config
               mountPath: /tmp/final
         {{- end }}
@@ -223,22 +264,29 @@ spec:
       volumes:
         {{- if (hasKey .Values.copia "config") }}
         - name: config
-          {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+          {{- if or (and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled) (eq "true" (include "copia.crossplane.enabled" .)) }}
           emptyDir: {}
           {{- else }}
           secret:
             secretName: {{ include "app.fullname" . }}-ini
           {{- end }}
-        {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
+        {{- if or (and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled) (eq "true" (include "copia.crossplane.enabled" .)) }}
         - name: app-ini-template
           secret:
             secretName: {{ include "app.fullname" . }}-ini
+        {{- end }}
+        {{- if and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled }}
         - name: gitea-secrets
           secret:
             secretName: {{ include "app.fullname" . }}-gitea-secrets
         - name: conversion-manager-secrets
           secret:
             secretName: conversion-manager-secrets
+        {{- end }}
+        {{- if eq "true" (include "copia.crossplane.enabled" .) }}
+        - name: db-secret
+          secret:
+            secretName: {{ include "copia.crossplane.connectionSecretName" . }}
         {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}

--- a/charts/copia/templates/copia-secret.yaml
+++ b/charts/copia/templates/copia-secret.yaml
@@ -10,6 +10,7 @@ stringData:
   app.ini: |
     {{- /* autogenerate app.ini */ -}}
     {{- $autoGen := and .Values.chartGeneratedSecrets .Values.chartGeneratedSecrets.enabled -}}
+    {{- $xpOn := eq "true" (include "copia.crossplane.enabled" .) -}}
     {{- $cfg := deepCopy .Values.copia.config -}}
     {{- if eq "true" (include "copia.cnpg.enabled" .) }}
       {{- if not (hasKey $cfg "database") }}
@@ -25,6 +26,26 @@ stringData:
       {{- end }}
       {{- if not (index $db "NAME") }}
         {{- $_ := set $db "NAME" (include "copia.database.name" .) }}
+      {{- end }}
+    {{- end }}
+    {{- if $xpOn }}
+      {{- $_ := include "copia.crossplane.validateHosts" . }}
+      {{- if not (hasKey $cfg "database") }}
+        {{- $_ := set $cfg "database" dict }}
+      {{- end }}
+      {{- $db := index $cfg "database" }}
+      {{- /* Filled at runtime from connection Secret by render-app-ini init. */ -}}
+      {{- $_ := set $db "HOST" "###XP_DB_HOST###" }}
+      {{- $_ := set $db "USER" "###XP_DB_USER###" }}
+      {{- $_ := set $db "PASSWD" "###XP_DB_PASSWD###" }}
+      {{- if not (index $db "DB_TYPE") }}
+        {{- $_ := set $db "DB_TYPE" "postgres" }}
+      {{- end }}
+      {{- if not (index $db "NAME") }}
+        {{- $_ := set $db "NAME" (include "copia.database.name" .) }}
+      {{- end }}
+      {{- if not (index $db "SSL_MODE") }}
+        {{- $_ := set $db "SSL_MODE" "require" }}
       {{- end }}
     {{- end }}
     {{- if $autoGen -}}

--- a/charts/copia/templates/crossplane-claim.yaml
+++ b/charts/copia/templates/crossplane-claim.yaml
@@ -1,0 +1,54 @@
+{{- if eq "true" (include "copia.crossplane.enabled" .) }}
+{{- $_ := include "copia.crossplane.validateHosts" . }}
+{{- $requireCRD := true }}
+{{- if and .Values.crossplane (hasKey .Values.crossplane "requireCRD") }}
+{{- $requireCRD = .Values.crossplane.requireCRD }}
+{{- end }}
+{{- if and $requireCRD (not (.Capabilities.APIVersions.Has "aws.copia.io/v1alpha1")) }}
+{{- fail "crossplane database provider requires PostgresInstance CRD (aws.copia.io/v1alpha1). Install the platform XRD + Composition first." }}
+{{- end }}
+{{- $params := dict
+      "region" "us-east-2"
+      "engineVersion" "15"
+      "instanceClass" "db.t4g.micro"
+      "allocatedStorage" 20
+      "dbName" (include "copia.database.name" .)
+      "username" (include "copia.database.user" .)
+      "providerConfigName" "default"
+      "skipFinalSnapshot" true
+}}
+{{- if and .Values.crossplane .Values.crossplane.providerConfigRef }}
+{{- $_ := set $params "providerConfigName" .Values.crossplane.providerConfigRef }}
+{{- end }}
+{{- if and .Values.crossplane .Values.crossplane.parameters }}
+{{- $params = mergeOverwrite $params .Values.crossplane.parameters }}
+{{- end }}
+{{- if or (not (hasKey $params "subnetIds")) (eq (len ($params.subnetIds | default list)) 0) }}
+{{- fail "crossplane.parameters.subnetIds is required (database/isolated subnet IDs for the Composition)." }}
+{{- end }}
+{{- if or (not (hasKey $params "vpcSecurityGroupIds")) (eq (len ($params.vpcSecurityGroupIds | default list)) 0) }}
+{{- fail "crossplane.parameters.vpcSecurityGroupIds is required (SG allowing 5432 from EKS workers)." }}
+{{- end }}
+{{- if not (hasKey $params "region") }}
+{{- fail "crossplane.parameters.region is required." }}
+{{- end }}
+---
+# Normal release resource (not a Helm hook). Helm must not wait on Claim Ready —
+# RDS takes 5–15 minutes. Pods/admin Job wait via pg_isready on the connection Secret.
+apiVersion: aws.copia.io/v1alpha1
+kind: PostgresInstance
+metadata:
+  name: {{ include "copia.crossplane.claimName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- if and .Values.crossplane .Values.crossplane.keepOnDelete }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  parameters:
+    {{- toYaml $params | nindent 4 }}
+  writeConnectionSecretToRef:
+    name: {{ include "copia.crossplane.connectionSecretName" . }}
+{{- end }}

--- a/charts/copia/templates/post-install-hooks.yaml
+++ b/charts/copia/templates/post-install-hooks.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.adminUser .Values.adminUser.create }}
+{{- $xpOn := eq "true" (include "copia.crossplane.enabled" .) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -15,9 +16,30 @@ data:
     set -eu
     apk add --no-cache argon2 >/dev/null
 
-    max_attempts=120
+    {{- if $xpOn }}
+    SECRET=/etc/db-secret
+    read_secret() {
+      for key in "$@"; do
+        if [ -e "${SECRET}/${key}" ]; then
+          tr -d '\n' < "${SECRET}/${key}"
+          return 0
+        fi
+      done
+      return 1
+    }
+    host="$(read_secret host endpoint address || true)"
+    host="${host%%:*}"
+    port="$(read_secret port || echo 5432)"
+    user="$(read_secret user username || true)"
+    pass="$(read_secret password attribute.password || true)"
+    db="$(read_secret dbname database || echo {{ include "copia.database.name" . | quote }})"
+    export PGHOST="$host" PGPORT="$port" PGUSER="$user" PGPASSWORD="$pass" PGDATABASE="$db"
+    export PGSSLMODE={{ (.Values.copia.config.database.SSL_MODE | default "require") | quote }}
+    {{- end }}
+
+    max_attempts=180
     attempt=0
-    until pg_isready -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t 2; do
+    until pg_isready -h "$PGHOST" -p "${PGPORT:-5432}" -U "$PGUSER" -d "$PGDATABASE" -t 2; do
       attempt=$((attempt + 1))
       [ "$attempt" -ge "$max_attempts" ] && echo "postgres readiness timeout" && exit 1
       echo "waiting for postgres..."; sleep 2
@@ -73,7 +95,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
-  activeDeadlineSeconds: 900
+  activeDeadlineSeconds: 1200
   ttlSecondsAfterFinished: 600
   template:
     spec:
@@ -83,6 +105,7 @@ spec:
           image: postgres:15-alpine
           command: ["/bin/sh", "/scripts/bootstrap.sh"]
           env:
+            {{- if not $xpOn }}
             - name: PGHOST
               value: {{ include "copia.database.host" . | quote }}
             - name: PGPORT
@@ -93,6 +116,7 @@ spec:
               value: {{ include "copia.database.name" . | quote }}
             - name: PGPASSWORD
               value: {{ .Values.copia.config.database.PASSWD | quote }}
+            {{- end }}
             - name: ADMIN_USERNAME
               value: {{ .Values.adminUser.username | quote }}
             - name: ADMIN_EMAIL
@@ -102,9 +126,19 @@ spec:
           volumeMounts:
             - name: script
               mountPath: /scripts
+            {{- if $xpOn }}
+            - name: db-secret
+              mountPath: /etc/db-secret
+              readOnly: true
+            {{- end }}
       volumes:
         - name: script
           configMap:
             name: {{ include "app.fullname" . }}-admin-bootstrap-script
             defaultMode: 0755
+        {{- if $xpOn }}
+        - name: db-secret
+          secret:
+            secretName: {{ include "copia.crossplane.connectionSecretName" . }}
+        {{- end }}
 {{- end }}

--- a/charts/copia/tests/conversion_manager_secrets_hook_test.yaml
+++ b/charts/copia/tests/conversion_manager_secrets_hook_test.yaml
@@ -14,6 +14,14 @@ tests:
       - hasDocuments:
           count: 4
 
+  - it: should still render when conversion_manager_service is disabled
+    set:
+      chartGeneratedSecrets.enabled: true
+      conversion_manager_service.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 4
+
   - it: ServiceAccount has correct hook annotations
     set:
       chartGeneratedSecrets.enabled: true

--- a/charts/copia/tests/crossplane_claim_test.yaml
+++ b/charts/copia/tests/crossplane_claim_test.yaml
@@ -1,0 +1,84 @@
+suite: Test Crossplane Postgres Claim
+templates:
+  - crossplane-claim.yaml
+tests:
+  - it: renders nothing when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: fails when enabled without the CRD
+    set:
+      database.provider: crossplane
+      crossplane.parameters.region: us-east-2
+      crossplane.parameters.subnetIds: ["subnet-a", "subnet-b"]
+      crossplane.parameters.vpcSecurityGroupIds: ["sg-a"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "PostgresInstance CRD"
+  - it: fails when enabled with an external database HOST
+    capabilities:
+      apiVersions:
+        - aws.copia.io/v1alpha1
+    set:
+      crossplane.enabled: true
+      copia.config.database.HOST: postgres.example.com:5432
+      crossplane.parameters.region: us-east-2
+      crossplane.parameters.subnetIds: ["subnet-a", "subnet-b"]
+      crossplane.parameters.vpcSecurityGroupIds: ["sg-a"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "omit copia.config.database.HOST"
+  - it: fails when subnetIds missing
+    capabilities:
+      apiVersions:
+        - aws.copia.io/v1alpha1
+    set:
+      database.provider: crossplane
+      crossplane.parameters.region: us-east-2
+      crossplane.parameters.vpcSecurityGroupIds: ["sg-a"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "subnetIds"
+  - it: fails when both crossplane and cloudnativePG are enabled
+    capabilities:
+      apiVersions:
+        - aws.copia.io/v1alpha1
+        - postgresql.cnpg.io/v1
+    set:
+      crossplane.enabled: true
+      cloudnativePG.enabled: true
+      copia.config.database.PASSWD: s3cret
+      crossplane.parameters.region: us-east-2
+      crossplane.parameters.subnetIds: ["subnet-a", "subnet-b"]
+      crossplane.parameters.vpcSecurityGroupIds: ["sg-a"]
+    asserts:
+      - failedTemplate:
+          errorPattern: "cannot both be enabled"
+  - it: renders Claim with connection secret ref when enabled via database.provider
+    capabilities:
+      apiVersions:
+        - aws.copia.io/v1alpha1
+    set:
+      database.provider: crossplane
+      crossplane.claimName: copia-poc-pg
+      crossplane.connectionSecretName: copia-db-app
+      crossplane.parameters.region: us-east-2
+      crossplane.parameters.subnetIds: ["subnet-a", "subnet-b", "subnet-c"]
+      crossplane.parameters.vpcSecurityGroupIds: ["sg-poc"]
+      crossplane.parameters.instanceClass: db.t4g.micro
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PostgresInstance
+      - equal:
+          path: metadata.name
+          value: copia-poc-pg
+      - equal:
+          path: spec.writeConnectionSecretToRef.name
+          value: copia-db-app
+      - equal:
+          path: spec.parameters.region
+          value: us-east-2
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]

--- a/charts/copia/values.schema.json
+++ b/charts/copia/values.schema.json
@@ -501,6 +501,48 @@
         }
       }
     },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional provider switch. Set provider to crossplane as an alias for crossplane.enabled.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Empty (external HOST/PASSWD), or \"crossplane\"."
+        }
+      }
+    },
+    "crossplane": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional AWS RDS via Crossplane PostgresInstance Claim. Platform must install Crossplane + XRD/Composition.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "requireCRD": {
+          "type": "boolean"
+        },
+        "keepOnDelete": {
+          "type": "boolean"
+        },
+        "claimName": {
+          "type": "string"
+        },
+        "connectionSecretName": {
+          "type": "string"
+        },
+        "providerConfigRef": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Merged into Claim spec.parameters (region, subnetIds, vpcSecurityGroupIds, ...)."
+        }
+      }
+    },
 
     "resources": {
       "type": "object",

--- a/charts/copia/values.yaml
+++ b/charts/copia/values.yaml
@@ -277,3 +277,26 @@ cloudnativePG:
   # Merged into the Cluster spec (postgresql.parameters, backup, monitoring, ...).
   extraSpec: {}
 
+# Optional database provider switch. Set to "crossplane" as an alias for
+# crossplane.enabled=true (Step 10: --set database.provider=crossplane).
+# Mutually exclusive with cloudnativePG.enabled.
+database:
+  provider: ""
+
+# AWS RDS via Crossplane Claim. Platform must install Crossplane, the AWS
+# provider, ProviderConfig (IRSA), and the PostgresInstance XRD + Composition.
+# The chart emits a Claim (pre-install hook) and reads credentials at runtime
+# from the connection Secret (nexus keys: user, password, host, port, dbname).
+# Omit HOST and PASSWD when enabled. See docs/distr/crossplane.md.
+crossplane:
+  enabled: false
+  requireCRD: true
+  keepOnDelete: false
+  # Default: <release-fullname>-pg
+  claimName: ""
+  connectionSecretName: copia-db-app
+  providerConfigRef: default
+  # Merged into Claim spec.parameters. subnetIds + vpcSecurityGroupIds + region
+  # are required until the Composition learns tag-based subnet discovery.
+  parameters: {}
+

--- a/docs/distr/crossplane.md
+++ b/docs/distr/crossplane.md
@@ -1,0 +1,126 @@
+# Crossplane Config
+
+This guide covers provisioning Copia's Postgres on **AWS RDS via Crossplane**.
+The chart emits a `PostgresInstance` Claim (pre-install hook) and reads
+credentials at **runtime** from a connection Secret. It does **not** install
+Crossplane or the AWS provider.
+
+Use this for the AWS / Distr path once Crossplane is a platform capability.
+For local/docker, keep using CloudNativePG (`cloudnativePG.enabled`).
+
+## Prerequisites (platform)
+
+1. Crossplane core installed and healthy
+2. Upbound AWS RDS provider + `ProviderConfig` (IRSA / Pod Identity)
+3. XRD + Composition for `PostgresInstance` (`aws.copia.io/v1alpha1`) that:
+   - Creates subnet group + RDS instance
+   - Writes a connection Secret with **nexus keys**: `user`, `password`, `host`,
+     `port`, `dbname` (remap from Crossplane's `username` / `endpoint` / …)
+4. Network inputs available to the Claim (until Composition does tag lookup):
+   - database/isolated subnet IDs
+   - security group allowing **5432** from EKS workers
+
+Example XRD/Composition for a staging spike live under
+`charts/copia/examples/crossplane/` (Crossplane **v2 pipeline** Composition +
+`function-patch-and-transform`).
+
+```bash
+kubectl apply -k charts/copia/examples/crossplane
+kubectl wait function.pkg.crossplane.io/function-patch-and-transform \
+  --for=condition=Healthy --timeout=2m
+kubectl get crd postgresinstances.aws.copia.io
+kubectl get composition xpostgresinstances.aws.copia.io
+```
+
+## Customer / smoke values
+
+Enable Crossplane and **omit** `HOST` and `PASSWD`. Supply Claim network
+parameters (staging spike) and an admin password for the post-install Job.
+
+```yaml
+database:
+  provider: crossplane   # or: crossplane.enabled: true
+crossplane:
+  connectionSecretName: copia-db-app
+  parameters:
+    region: us-east-2
+    subnetIds:
+      - subnet-aaa
+      - subnet-bbb
+      - subnet-ccc
+    vpcSecurityGroupIds:
+      - sg-poc-rds
+chartGeneratedSecrets:
+  enabled: true
+adminUser:
+  create: true
+  username: admin
+  email: admin@example.com
+  password: "test-admin-password"
+copia:
+  config:
+    database:
+      NAME: copia
+      USER: copia
+      SSL_MODE: require
+      # omit HOST and PASSWD
+```
+
+Do **not** enable `cloudnativePG` at the same time.
+
+## How the chart behaves
+
+1. Helm applies a `PostgresInstance` Claim with the release (not a pre-install
+   hook — Helm must not wait on RDS Ready, which takes 5–15 minutes).
+2. Crossplane reconciles the Claim → AWS RDS → Secret `copia-db-app`.
+3. Deployment **init** mounts the Secret and runs `pg_isready` / `psql`
+   (kubelet blocks start until the Secret exists).
+4. `render-app-ini` substitutes `HOST` / `USER` / `PASSWD` from the Secret
+   (placeholders `###XP_DB_*###`).
+5. Post-install **admin bootstrap** Job also reads the Secret (not Helm values).
+
+## Step 10 smoke (second namespace)
+
+Disable conversion-manager for the spike (avoids its secrets-init Job). Use a
+real image and skip the GHCR preflight Job.
+
+```bash
+# After XRD+Composition are installed and you have subnet/SG IDs:
+helm install copia-poc ./charts/copia -n crossplane-poc --create-namespace \
+  --timeout 20m \
+  --values charts/copia/distr/values.base.yaml \
+  --set image.repository=ghcr.io/copia-automation/copia-web-app-selfhosted-releases \
+  --set image.tag=v0.57.0 \
+  --set ghcrCheck=false \
+  --set conversion_manager_service.enabled=false \
+  --set database.provider=crossplane \
+  --set chartGeneratedSecrets.enabled=true \
+  --set adminUser.create=true \
+  --set adminUser.username=admin \
+  --set adminUser.email=admin@example.com \
+  --set adminUser.password='test-admin-password' \
+  --set copia.config.database.HOST= \
+  --set crossplane.parameters.region=us-east-2 \
+  --set-json 'crossplane.parameters.subnetIds=["subnet-aaa","subnet-bbb","subnet-ccc"]' \
+  --set-json 'crossplane.parameters.vpcSecurityGroupIds=["sg-poc"]'
+```
+
+Verify:
+
+```bash
+kubectl get postgresinstance -n crossplane-poc
+kubectl get secret copia-db-app -n crossplane-poc -o json | jq -r '.data | keys[]'
+kubectl logs -n crossplane-poc -l app.kubernetes.io/name=copia -c copia-wait-db
+kubectl logs -n crossplane-poc job/copia-poc-copia-admin-bootstrap
+```
+
+Port-forward and log in with `admin` / your test admin password once the
+Deployment is Ready.
+
+## Cleanup
+
+```bash
+helm uninstall copia-poc -n crossplane-poc
+# wait for Claim/RDS finalizers; confirm instance gone in AWS
+kubectl delete postgresinstance -n crossplane-poc --all
+```

--- a/docs/distr/install.md
+++ b/docs/distr/install.md
@@ -28,7 +28,7 @@ fields keep **Deploy** disabled.
 
 ### Database
 
-Copia needs PostgreSQL. Two supported layouts:
+Copia needs PostgreSQL. Supported layouts:
 
 - **External Postgres** (default customer values) — set `copia.config.database.HOST`
   and conversion-manager `DB_HOST` to your server.
@@ -39,7 +39,12 @@ Copia needs PostgreSQL. Two supported layouts:
   `cloudnativePG.enabled: true` and remove `HOST` / `DB_HOST`. The chart creates
   a `Cluster` CR and points the apps at it. See
   [CloudNativePG Config](./cloudnativepg.md).
-  Do not use `CORE_ADDONS__DATABASE__*` with Core `v0.7.0`.
+- **AWS RDS via Crossplane** (platform spike / future Distr AWS path) — platform
+  installs Crossplane + Composition; chart uses `database.provider=crossplane`
+  (or `crossplane.enabled`) and reads `copia-db-app`. Omit `HOST` / `PASSWD`.
+  See [Crossplane Config](./crossplane.md).
+
+Do not use `CORE_ADDONS__DATABASE__*` with Core `v0.7.0`.
 
 ## Install the Kubernetes agent
 

--- a/script/render-check.sh
+++ b/script/render-check.sh
@@ -23,6 +23,18 @@ main() {
     --set conversion_manager_service.configmap.DB_HOST= \
     >/dev/null
   log::success "Distr overlay with cloudnativePG.enabled renders cleanly"
+
+  log::exec_command helm template copia charts/copia \
+    --api-versions aws.copia.io/v1alpha1 \
+    --values charts/copia/distr/values.base.yaml \
+    --set database.provider=crossplane \
+    --set chartGeneratedSecrets.enabled=true \
+    --set copia.config.database.HOST= \
+    --set crossplane.parameters.region=us-east-2 \
+    --set-json 'crossplane.parameters.subnetIds=["subnet-a","subnet-b"]' \
+    --set-json 'crossplane.parameters.vpcSecurityGroupIds=["sg-a"]' \
+    >/dev/null
+  log::success "Chart with database.provider=crossplane renders cleanly"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- Adds `database.provider=crossplane` / `crossplane.enabled` as a CNPG-parallel path: chart emits a `PostgresInstance` Claim and consumes the `copia-db-app` connection Secret at runtime (`pg_isready` + `render-app-ini` + admin bootstrap).
- Documents the platform prerequisites and smoke install in `docs/distr/crossplane.md`, with example XRD/Composition under `charts/copia/examples/crossplane/`.
- Keeps `conversion-manager-secrets` generation gated only on `chartGeneratedSecrets` (not CM enabled), so installs that disable conversion-manager still get the Secret the Deployment mounts.

## Test plan
- [ ] `helm unittest` / CI chart tests pass
- [ ] Review Claim is **not** a Helm pre-install hook that waits on RDS Ready
- [ ] Staging smoke (already done in `crossplane-poc`): Claim → Secret → wait init → admin bootstrap → login with test admin
- [ ] Confirm mutual exclusion with `cloudnativePG.enabled`
- [ ] Confirm `chartGeneratedSecrets=true` + `conversion_manager_service.enabled=false` still creates `conversion-manager-secrets`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Crossplane support for provisioning AWS RDS PostgreSQL databases.
  - Added configurable claims, connection Secrets, provider settings, networking, retention, and PostgreSQL parameters.
  - Added runtime credential handling and database readiness checks.
  - Added example Crossplane resources and deployment configuration.

- **Documentation**
  - Added Crossplane setup, installation, verification, and cleanup guidance.
  - Updated database deployment documentation with the AWS RDS option.

- **Bug Fixes**
  - Improved generated Secret handling and PostgreSQL readiness retries.

- **Tests**
  - Added rendering and validation coverage for Crossplane configurations and Secret hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->